### PR TITLE
fix: jax 0.11.0 compatibility (Inline enum, scan_p params, unstack)

### DIFF
--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -11,10 +11,12 @@ __all__ = (
     # Features
     "jit_p",
     "is_early_inline",
+    "scan_bind_params",
     "typeof",
+    "unpack_scan_args",
 )
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from importlib.metadata import version
 from typing import Any, Final
 
@@ -61,6 +63,78 @@ else:
     def is_early_inline(inline: Any, /) -> bool:
         """Whether `jit_p`'s `inline` parameter asks for inlining at trace time."""
         return bool(inline)
+
+
+# JAX 0.11.0 reworked `scan_p`'s parameters: the positional `num_consts` /
+# `num_carry` split (plus `linear` and `_split_transpose`) was replaced by a
+# pair of `FlatTree` descriptors, `ft_in` and `ft_out`, which describe the
+# const/carry/xs grouping of the inputs and the carry/ys grouping of the
+# outputs.
+#
+# `unpack_scan_args` recovers the (consts, carry, xs) grouping, and
+# `scan_bind_params` builds the parameters for re-binding `scan_p` with a
+# quaxified body -- which generally has a *different* number of flat operands,
+# since a single `ArrayValue` can flatten to several arrays.
+if JAX_GE_0_11_0:
+    from jax._src import (
+        flattree as jax_flattree,  # pyright: ignore[reportAttributeAccessIssue]
+    )
+
+    def unpack_scan_args(
+        args: Sequence[Any], params: dict[str, Any], /
+    ) -> tuple[list, list, list]:
+        """Split `scan_p`'s flat operands into (consts, carry, xs)."""
+        groups = params["ft_in"].update(args).unpack()
+        return tuple(list(g.vals) for g in groups)  # type: ignore[return-value]
+
+    def scan_bind_params(
+        params: dict[str, Any],
+        /,
+        *,
+        num_consts: int,
+        num_carry: int,
+        num_xs: int,
+        num_ys: int,
+    ) -> dict[str, Any]:
+        """Parameters for re-binding `scan_p` with the given group sizes.
+
+        The rebuilt `ft_in`/`ft_out` use plain `nones`: the quaxified body is
+        retraced from scratch, so none of the caller's forwarding or filtering
+        optimizations (e.g. the `RightsOnly` markers JAX uses to prune extensive
+        outputs) carry over to it.
+        """
+        rest = {k: v for k, v in params.items() if k not in ("ft_in", "ft_out")}
+        nones = jax_flattree.nones
+        return {
+            **rest,
+            "ft_in": jax_flattree.pack(
+                (nones(num_consts), nones(num_carry), nones(num_xs))
+            ),
+            "ft_out": jax_flattree.pack((nones(num_carry), nones(num_ys))),
+        }
+
+else:
+
+    def unpack_scan_args(
+        args: Sequence[Any], params: dict[str, Any], /
+    ) -> tuple[list, list, list]:
+        """Split `scan_p`'s flat operands into (consts, carry, xs)."""
+        nc = params["num_consts"]
+        body_end = nc + params["num_carry"]
+        return list(args[:nc]), list(args[nc:body_end]), list(args[body_end:])
+
+    def scan_bind_params(
+        params: dict[str, Any],
+        /,
+        *,
+        num_consts: int,
+        num_carry: int,
+        num_xs: int,
+        num_ys: int,
+    ) -> dict[str, Any]:
+        """Parameters for re-binding `scan_p` with the given group sizes."""
+        del num_xs, num_ys
+        return {**params, "num_consts": num_consts, "num_carry": num_carry}
 
 
 typeof: Callable[[Any], Any]

--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -7,8 +7,10 @@ __all__ = (
     "JAX_GE_0_9_2",
     "JAX_GE_0_10_1",
     "JAX_GE_0_10_2",
+    "JAX_GE_0_11_0",
     # Features
     "jit_p",
+    "is_early_inline",
     "typeof",
 )
 
@@ -31,12 +33,35 @@ JAX_GE_0_8_2: Final = JAX_VERSION >= Version("0.8.2")
 JAX_GE_0_9_2: Final = JAX_VERSION >= Version("0.9.2")
 JAX_GE_0_10_1: Final = JAX_VERSION >= Version("0.10.1")
 JAX_GE_0_10_2: Final = JAX_VERSION >= Version("0.10.2")
+JAX_GE_0_11_0: Final = JAX_VERSION >= Version("0.11.0")
 
 jit_p: jexc.Primitive
 if JAX_GE_0_7_0:
     jit_p = jax._src.pjit.jit_p  # pyright: ignore[reportAttributeAccessIssue]
 else:
     jit_p = jax._src.pjit.pjit_p  # pyright: ignore[reportAttributeAccessIssue]
+
+# JAX 0.11.0 changed `jit_p`'s `inline` parameter from a `bool` to the
+# `jax.Inline` enum: the old `True` became `Inline.JAX_EARLY` and the old
+# `False` became `Inline.AUTO` (see `jax._src.pjit._canonicalize_inline`).
+# Enum members are always truthy, so `bool(inline)` is no longer a valid test
+# for "JAX asked us to inline the body at trace time"; only `JAX_EARLY` means
+# that. The other members keep the call in the jaxpr and defer inlining to
+# lowering or to XLA, which is the same structural situation as the old
+# `False`.
+is_early_inline: Callable[[Any], bool]
+if JAX_GE_0_11_0:
+
+    def is_early_inline(inline: Any, /) -> bool:
+        """Whether `jit_p`'s `inline` parameter asks for inlining at trace time."""
+        return inline is True or inline is jax.Inline.JAX_EARLY  # pyright: ignore[reportAttributeAccessIssue]
+
+else:
+
+    def is_early_inline(inline: Any, /) -> bool:
+        """Whether `jit_p`'s `inline` parameter asks for inlining at trace time."""
+        return bool(inline)
+
 
 typeof: Callable[[Any], Any]
 if JAX_GE_0_8_2:

--- a/src/quax/_primitives.py
+++ b/src/quax/_primitives.py
@@ -11,7 +11,7 @@ import jax.extend.core as jexc
 import jax.tree_util as jtu
 from jaxtyping import ArrayLike
 
-from ._compat import is_early_inline, jit_p
+from ._compat import is_early_inline, jit_p, scan_bind_params, unpack_scan_args
 from ._dispatch import register
 from ._quaxify import _Quaxify, quaxify
 from ._values import _make_cache_finalizer, ArrayValue
@@ -171,22 +171,25 @@ _scan_quax_cache: dict[tuple, tuple] = {}
 
 
 @register(jax.lax.scan_p)
-def scan_quax(
-    *args: ArrayValue | ArrayLike, num_consts: int, num_carry: int, jaxpr, **kwargs: Any
-) -> Any:
+def scan_quax(*args: ArrayValue | ArrayLike, jaxpr, **kwargs: Any) -> Any:
     """Quax handler for ``lax.scan_p``.
 
     Splits the flat ``args`` sequence into the three groups that ``lax.scan``
     uses — constants, initial carry, and stacked ``xs`` — then builds a
     quaxified jaxpr for the scan body and re-binds the primitive with it.
 
+    How that grouping is encoded in the primitive's parameters changed in JAX
+    0.11.0, so both the split and the re-bind go through `_compat`.
+
     The quaxified body jaxpr is cached by ``(id(jaxpr), consts_treedef,
     carry_treedef, xs_treedef)`` so that repeated calls with the same scan
     body and pytree structure skip the ``jax.make_jaxpr`` tracing step.
     """
-    consts_flat, c_tree = jtu.tree_flatten(args[:num_consts])
-    carry_flat, v_tree = jtu.tree_flatten(args[num_consts : num_consts + num_carry])
-    xs_flat, x_tree = jtu.tree_flatten(args[num_consts + num_carry :])
+    consts, carry, xs = unpack_scan_args(args, kwargs)
+
+    consts_flat, c_tree = jtu.tree_flatten(consts)
+    carry_flat, v_tree = jtu.tree_flatten(carry)
+    xs_flat, x_tree = jtu.tree_flatten(xs)
 
     nc = len(consts_flat)
     nv = len(carry_flat)
@@ -222,9 +225,13 @@ def scan_quax(
         *carry_flat,
         *xs_flat,
         jaxpr=quax_jaxpr,
-        num_consts=nc,
-        num_carry=nv,
-        **kwargs,
+        **scan_bind_params(
+            kwargs,
+            num_consts=nc,
+            num_carry=nv,
+            num_xs=len(xs_flat),
+            num_ys=len(quax_jaxpr.out_avals) - nv,
+        ),
     )
 
     return jtu.tree_unflatten(out_tree, out_flat)

--- a/src/quax/_primitives.py
+++ b/src/quax/_primitives.py
@@ -11,15 +11,15 @@ import jax.extend.core as jexc
 import jax.tree_util as jtu
 from jaxtyping import ArrayLike
 
-from ._compat import jit_p
+from ._compat import is_early_inline, jit_p
 from ._dispatch import register
 from ._quaxify import _Quaxify, quaxify
 from ._values import _make_cache_finalizer, ArrayValue
 
 
 # Cache for jit_quax: maps (id(jaxpr), treedef) -> (jaxpr_wref, jitted_fn).
-# Populated on any call where inline=False — both from eager mode and from the
-# JIT-inside-JIT path.  In both cases the jaxpr is stable (JAX's pjit layer
+# Populated on any call that is not inlined at trace time — both from eager mode
+# and from the JIT-inside-JIT path.  In both cases the jaxpr is stable (pjit
 # caches it keyed by function + abstract args), so id(jaxpr) is a reliable key.
 #
 # entry[0] is a weakref to the jaxpr; the finalizer evicts the entry when the
@@ -31,22 +31,26 @@ _jit_quax_cache: dict[tuple, tuple[Any, Any]] = {}
 
 @register(jit_p)
 def jit_quax(
-    *args: ArrayLike | ArrayValue, jaxpr: Any, inline: bool, **kwargs: Any
+    *args: ArrayLike | ArrayValue, jaxpr: Any, inline: Any, **kwargs: Any
 ) -> Any:
     del kwargs
 
-    # inline=True: JAX has already decided to inline the body — just re-quaxify
+    # `inline` is a bool before JAX 0.11.0 and a `jax.Inline` enum from 0.11.0
+    # on, so it is typed as `Any` here and interpreted by `is_early_inline`.
+    #
+    # Early inline: JAX has already decided to inline the body — just re-quaxify
     # and interpret it directly without the jax.jit wrapper overhead.
-    if inline:
+    if is_early_inline(inline):
         return quaxify(jexc.jaxpr_as_fun(jaxpr))(*args)
 
     leaves, treedef = jtu.tree_flatten(args)  # remove all Values
 
-    # inline=False path: cache the jax.jit-wrapped quaxify callable so the
+    # Non-inlined path: cache the jax.jit-wrapped quaxify callable so the
     # compiled XLA kernel is reused on subsequent calls with the same jaxpr.
     # This applies both for eager calls to a @jax.jit function and for nested
     # JIT tracing. id(jaxpr) is a reliable key here because the jaxpr is stable
-    # for a given cached JAX lowering, and inline is always False at this point.
+    # for a given cached JAX lowering, and inlining is never requested at this
+    # point.
     key = (id(jaxpr), treedef)
     entry = _jit_quax_cache.get(key)
     if entry is None:

--- a/tests/unit/myarray.py
+++ b/tests/unit/myarray.py
@@ -13,7 +13,7 @@ from jaxtyping import Array, ArrayLike, Bool
 from packaging.version import Version
 
 import quax
-from quax._compat import JAX_GE_0_10_1, JAX_VERSION, typeof
+from quax._compat import JAX_GE_0_10_1, JAX_GE_0_11_0, JAX_VERSION, typeof
 
 
 @final
@@ -1508,6 +1508,15 @@ def top_k_p(operand: MyArray, /, **kw: Any) -> list[MyArray]:
 @quax.register(lax.transpose_p)
 def transpose_p(operand: MyArray, /, **kw: Any) -> MyArray:
     return replace(operand, array=lax.transpose_p.bind(operand.array, **kw))
+
+
+# ==============================================================================
+
+if JAX_GE_0_11_0:
+
+    @quax.register(lax.unstack_p)
+    def unstack_p(x: MyArray, /, **kw: Any) -> list[MyArray]:
+        return [MyArray(y) for y in lax.unstack_p.bind(x.array, **kw)]
 
 
 # ==============================================================================

--- a/tests/unit/test_jit_quax_cache.py
+++ b/tests/unit/test_jit_quax_cache.py
@@ -5,12 +5,13 @@ Two structural assumptions are verified:
 1. JAX's jaxpr is stable (same Python object) across repeated traces with
    identical argument avals, making id(jaxpr) a reliable cache key.
 2. The cache key is (id(jaxpr), treedef) — inline is NOT part of the key;
-   inline=True calls bypass the cache entirely (early return).
+   calls that JAX asked to inline at trace time bypass the cache entirely
+   (early return).
 
 Plus the GC-safety invariant: cache entries store weakrefs to the jaxpr so
 the finalizer can evict stale entries, preventing unbounded cache growth.
 
-Both eager mode and JIT-inside-JIT mode populate the cache (inline=False only).
+Both eager mode and JIT-inside-JIT mode populate the cache (non-inlined only).
 The jaxpr is kept alive by JAX's own pjit layer, so the weakref finalizer is
 rarely if ever triggered in normal usage.
 """
@@ -21,9 +22,10 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
+import pytest
 
 import quax
-from quax._compat import jit_p
+from quax._compat import JAX_GE_0_11_0, jit_p
 from quax._primitives import _jit_quax_cache, jit_quax
 
 
@@ -263,4 +265,46 @@ def test_inline_true_bypasses_cache():
     assert set(_jit_quax_cache.keys()) == keys_before, (
         "inline=True must bypass _jit_quax_cache entirely — no entries "
         "should be added or removed."
+    )
+
+
+@pytest.mark.skipif(not JAX_GE_0_11_0, reason="jax.Inline was introduced in JAX 0.11.0")
+@pytest.mark.parametrize(
+    ("member", "inlines"),
+    [
+        ("JAX_EARLY", True),
+        ("JAX_LATE", False),
+        ("XLA_EARLY", False),
+        ("XLA_LATE", False),
+        ("AUTO", False),
+    ],
+)
+def test_inline_enum_members(member, inlines):
+    """From JAX 0.11.0 `inline` is a `jax.Inline` enum rather than a bool.
+    Only `JAX_EARLY` (the old `True`) takes the early-return path; every other
+    member keeps the call in the jaxpr and so must populate the cache, like the
+    old `False` did.  Enum members are all truthy, so a plain `if inline:`
+    would wrongly inline every one of them."""
+    _jit_quax_cache.clear()
+
+    @jax.jit
+    def inner(x):
+        return x + 1.0
+
+    def outer(x):
+        return inner(x)
+
+    closed_outer = jax.make_jaxpr(outer)(jnp.array(0.0))
+    inner_jaxpr = _extract_jit_jaxpr(closed_outer)
+    assert inner_jaxpr is not None, "No jit_p equation found in outer jaxpr"
+
+    inline = getattr(jax.Inline, member)
+    result = jit_quax(jnp.array(0.0), jaxpr=inner_jaxpr, inline=inline)
+
+    out = result[0] if isinstance(result, list) else result
+    assert float(out) == 1.0  # correct answer either way
+
+    assert (len(_jit_quax_cache) == 0) is inlines, (
+        f"Inline.{member} should {'bypass' if inlines else 'populate'} "
+        f"_jit_quax_cache, but the cache has {len(_jit_quax_cache)} entries."
     )

--- a/tests/unit/test_stage_value.py
+++ b/tests/unit/test_stage_value.py
@@ -6,24 +6,33 @@ from quax._trace import _QuaxTrace, _QuaxTracer
 from quax._values import _DenseArrayValue
 
 
+# `take_current_trace` leaves the current trace unset for the duration of the
+# block, so any JAX operation inside it has no trace to bind against. Build the
+# arrays up front and keep the block down to the code actually under test.
+
+
 def test_stage_value_lifts_array_to_quaxtracer():
+    arr = jnp.array([1.0, 2.0, 3.0])
+
     with core.take_current_trace() as parent_trace:
         trace = _QuaxTrace(parent_trace, core.TraceTag())
-        arr = jnp.array([1.0, 2.0, 3.0])
         t = trace.stage_value(arr)
-        assert isinstance(t, _QuaxTracer)
-        assert isinstance(t.value, _DenseArrayValue)
-        assert jnp.array_equal(t.value.array, arr)
+
+    assert isinstance(t, _QuaxTracer)
+    assert isinstance(t.value, _DenseArrayValue)
+    assert jnp.array_equal(t.value.array, arr)
 
 
 def test_stage_value_handles_symbolic_zero():
     # SymbolicZero should be returned unchanged (JAX expects SZ handling).
+    sz = SZ(jnp.array(0.0).aval) if hasattr(SZ, "__call__") else SZ
+
     with core.take_current_trace() as parent_trace:
         trace = _QuaxTrace(parent_trace, core.TraceTag())
-        sz = SZ(jnp.array(0.0).aval) if hasattr(SZ, "__call__") else SZ
         # We expect the trace to accept SZ and return it as-is or wrapped
         # appropriately; the exact behavior is implementation defined but should
         # not raise NotImplementedError.
         res = trace.stage_value(sz)
-        # Either returns the SZ sentinel or a tracer that carries it.
-        assert res is not None
+
+    # Either returns the SZ sentinel or a tracer that carries it.
+    assert res is not None


### PR DESCRIPTION
Fixes the `newest-deps` failures in [Weekly CI run 29728262573](https://github.com/nstarman/quax/actions/runs/29728262573).

CI reported **578 failed, 404 passed** on jax 0.11.0. That was one loud error masking three quieter ones — each fix uncovered the next.

## 1. `jit_p`'s `inline` parameter is now an enum (578 → 25 failures)

JAX 0.11.0 [added `jax.Inline`](https://github.com/jax-ml/jax/blob/main/CHANGELOG.md) and changed `jit_p`'s `inline` parameter from a `bool` to that enum, so beartype rejected `jit_quax`'s `inline: bool` annotation on essentially every call:

```
beartype.roar.BeartypeCallHintParamViolation: Function quax._primitives.jit_quax()
parameter inline=<Inline.AUTO: 'auto'> violates type hint <class 'bool'>
```

**Widening the annotation alone would have been a silent bug.** `_canonicalize_inline` maps the old `True` to `Inline.JAX_EARLY` and the old `False` to `Inline.AUTO`. Enum members are always truthy, so leaving `if inline:` in place would take the early-inline path for the *default* `AUTO` — bypassing `_jit_quax_cache` on every jit call and losing the compiled-kernel reuse the cache exists for. Tests would have passed; the cache would have quietly stopped working.

Only `JAX_EARLY` means "inlined during JAX tracing". `JAX_LATE`/`XLA_EARLY`/`XLA_LATE` keep the call in the jaxpr and defer inlining to lowering or to XLA — structurally the old `False`. Added an `is_early_inline` compat helper and a parametrized test pinning the behaviour of all five members.

## 2. `scan_p`'s parameters were reworked (25 → 11)

`num_consts`/`num_carry` (plus `linear` and `_split_transpose`) were replaced by a pair of `FlatTree` descriptors, `ft_in`/`ft_out`, describing the const/carry/xs grouping of the inputs and the carry/ys grouping of the outputs.

Added `unpack_scan_args`/`scan_bind_params` compat helpers. `scan_quax` has to rebuild these descriptors rather than pass them through: a quaxified body generally has a *different* number of flat operands than the original, since one `ArrayValue` can flatten to several arrays. The rebuilt descriptors use plain `nones` — the body is retraced from scratch, so the caller's forwarding/filtering optimizations (the `RightsOnly` markers JAX uses to prune extensive outputs) don't apply to it.

## 3. `take_current_trace()` now unsets the current trace

The two `test_stage_value` tests built their arrays *inside* the `with` block, where there is no longer a trace to bind against. Moved the array construction ahead of the block, leaving only the code under test inside.

## 4. New `lax.unstack_p` primitive (11 → 0)

jax 0.11.0 added `unstack_p`, and `jnp.lexsort` now routes through it. The `MyArray` test fixture had no rule for it, so every `lexsort`-backed function — `unique*`, `union1d`, `setdiff1d`, `setxor1d`, `intersect1d` — fell through to `materialise` (which the fixture deliberately raises on, to catch exactly this). Registered a rule, mirroring the existing `stack_p` one.

## Verification

Run locally against a real jax 0.11.0 install and against the lockfile's jax 0.8.1:

| | before | after |
|---|---|---|
| jax 0.11.0 | 578 failed, 404 passed | **944 passed, 0 failed** |
| jax 0.8.1 (lockfile) | 941 passed | **941 passed, 0 failed** |

Every version-dependent branch is gated on a new `JAX_GE_0_11_0` flag, following the existing `jit_p`/`typeof` pattern in `_compat.py`, so the pre-0.11 path is byte-for-byte the old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
