### PR TITLE
Backport PR #164 on branch versions/v0.3.x (🐛 fix: support JAX 0.11 compatibility changes)

### DIFF
--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -1,6 +1,6 @@
 """Compatibility utilities."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from importlib.metadata import version
 from typing import Any, Final
 
@@ -19,9 +19,13 @@ __all__ = (
     "JAX_GE_0_9_2",
     "JAX_GE_0_10_1",
     "JAX_GE_0_10_2",
+    "JAX_GE_0_11_0",
     # Features
     "jit_p",
+    "is_early_inline",
+    "scan_bind_params",
     "typeof",
+    "unpack_scan_args",
 )
 
 JAX_VERSION: Final = Version(version("jax"))
@@ -31,12 +35,107 @@ JAX_GE_0_8_2: Final = JAX_VERSION >= Version("0.8.2")
 JAX_GE_0_9_2: Final = JAX_VERSION >= Version("0.9.2")
 JAX_GE_0_10_1: Final = JAX_VERSION >= Version("0.10.1")
 JAX_GE_0_10_2: Final = JAX_VERSION >= Version("0.10.2")
+JAX_GE_0_11_0: Final = JAX_VERSION >= Version("0.11.0")
 
 jit_p: jexc.Primitive
 if JAX_GE_0_7_0:
     jit_p = jax._src.pjit.jit_p  # pyright: ignore[reportAttributeAccessIssue]
 else:
     jit_p = jax._src.pjit.pjit_p  # pyright: ignore[reportAttributeAccessIssue]
+
+# JAX 0.11.0 changed `jit_p`'s `inline` parameter from a `bool` to the
+# `jax.Inline` enum: the old `True` became `Inline.JAX_EARLY` and the old
+# `False` became `Inline.AUTO` (see `jax._src.pjit._canonicalize_inline`).
+# Enum members are always truthy, so `bool(inline)` is no longer a valid test
+# for "JAX asked us to inline the body at trace time"; only `JAX_EARLY` means
+# that. The other members keep the call in the jaxpr and defer inlining to
+# lowering or to XLA, which is the same structural situation as the old
+# `False`.
+is_early_inline: Callable[[Any], bool]
+if JAX_GE_0_11_0:
+
+    def is_early_inline(inline: Any, /) -> bool:
+        """Whether `jit_p`'s `inline` parameter asks for inlining at trace time."""
+        return inline is True or inline is jax.Inline.JAX_EARLY  # pyright: ignore[reportAttributeAccessIssue]
+
+else:
+
+    def is_early_inline(inline: Any, /) -> bool:
+        """Whether `jit_p`'s `inline` parameter asks for inlining at trace time."""
+        return bool(inline)
+
+
+# JAX 0.11.0 reworked `scan_p`'s parameters: the positional `num_consts` /
+# `num_carry` split (plus `linear` and `_split_transpose`) was replaced by a
+# pair of `FlatTree` descriptors, `ft_in` and `ft_out`, which describe the
+# const/carry/xs grouping of the inputs and the carry/ys grouping of the
+# outputs.
+#
+# `unpack_scan_args` recovers the (consts, carry, xs) grouping, and
+# `scan_bind_params` builds the parameters for re-binding `scan_p` with a
+# quaxified body -- which generally has a *different* number of flat operands,
+# since a single `ArrayValue` can flatten to several arrays.
+if JAX_GE_0_11_0:
+    from jax._src import (
+        flattree as jax_flattree,  # pyright: ignore[reportAttributeAccessIssue]
+    )
+
+    def unpack_scan_args(
+        args: Sequence[Any], params: dict[str, Any], /
+    ) -> tuple[list, list, list]:
+        """Split `scan_p`'s flat operands into (consts, carry, xs)."""
+        groups = params["ft_in"].update(args).unpack()
+        return tuple(list(g.vals) for g in groups)  # type: ignore[return-value]
+
+    def scan_bind_params(
+        params: dict[str, Any],
+        /,
+        *,
+        num_consts: int,
+        num_carry: int,
+        num_xs: int,
+        num_ys: int,
+    ) -> dict[str, Any]:
+        """Parameters for re-binding `scan_p` with the given group sizes.
+
+        The rebuilt `ft_in`/`ft_out` use plain `nones`: the quaxified body is
+        retraced from scratch, so none of the caller's forwarding or filtering
+        optimizations (e.g. the `RightsOnly` markers JAX uses to prune extensive
+        outputs) carry over to it.
+        """
+        rest = {k: v for k, v in params.items() if k not in ("ft_in", "ft_out")}
+        nones = jax_flattree.nones
+        return {
+            **rest,
+            "ft_in": jax_flattree.pack(
+                (nones(num_consts), nones(num_carry), nones(num_xs))
+            ),
+            "ft_out": jax_flattree.pack((nones(num_carry), nones(num_ys))),
+        }
+
+else:
+
+    def unpack_scan_args(
+        args: Sequence[Any], params: dict[str, Any], /
+    ) -> tuple[list, list, list]:
+        """Split `scan_p`'s flat operands into (consts, carry, xs)."""
+        nc = params["num_consts"]
+        body_end = nc + params["num_carry"]
+        return list(args[:nc]), list(args[nc:body_end]), list(args[body_end:])
+
+    def scan_bind_params(
+        params: dict[str, Any],
+        /,
+        *,
+        num_consts: int,
+        num_carry: int,
+        num_xs: int,
+        num_ys: int,
+    ) -> dict[str, Any]:
+        """Parameters for re-binding `scan_p` with the given group sizes."""
+        del num_xs, num_ys
+        return {**params, "num_consts": num_consts, "num_carry": num_carry}
+
 
 typeof: Callable[[Any], Any]
 if JAX_GE_0_8_2:

--- a/src/quax/_core.py
+++ b/src/quax/_core.py
@@ -15,7 +15,14 @@ import plum
 from jax.custom_derivatives import SymbolicZero as SZ
 from jaxtyping import ArrayLike, PyTree
 
-from ._compat import JAX_GE_0_9_2, jit_p, typeof
+from ._compat import (
+    is_early_inline,
+    JAX_GE_0_9_2,
+    jit_p,
+    scan_bind_params,
+    typeof,
+    unpack_scan_args,
+)
 
 
 T = TypeVar("T")
@@ -615,11 +622,15 @@ class _DenseArrayValue(ArrayValue):
 
 @register(jit_p)
 def jit_quax(
-    *args: ArrayLike | ArrayValue, jaxpr: Any, inline: bool, **kwargs: Any
+    *args: ArrayLike | ArrayValue, jaxpr: Any, inline: Any, **kwargs: Any
 ) -> Any:
     del kwargs
     fun = quaxify(jexc.jaxpr_as_fun(jaxpr))
-    if inline:
+    # `inline` is a bool before JAX 0.11.0 and a `jax.Inline` enum from 0.11.0
+    # on, so it is typed as `Any` here and interpreted by `is_early_inline`.
+    # Enum members are always truthy, so a bare `if inline:` would wrongly
+    # inline on every call under 0.11.
+    if is_early_inline(inline):
         return fun(*args)
 
     leaves, treedef = jtu.tree_flatten(args)  # remove all Values
@@ -708,16 +719,16 @@ def cond_quax(
 @register(jax.lax.scan_p)
 def _(
     *args: ArrayValue | ArrayLike,
-    num_consts: int,
-    num_carry: int,
     jaxpr,
     **kwargs,
 ):
-    consts_flat, consts_struct = jtu.tree_flatten(args[:num_consts])
-    carry_flat, carry_struct = jtu.tree_flatten(
-        args[num_consts : num_consts + num_carry]
-    )
-    xs_flat, xs_struct = jtu.tree_flatten(args[num_consts + num_carry :])
+    # How the const/carry/xs grouping is encoded in `scan_p`'s parameters
+    # changed in JAX 0.11.0, so both the split and the re-bind go via `_compat`.
+    consts, carry, xs = unpack_scan_args(args, kwargs)
+
+    consts_flat, consts_struct = jtu.tree_flatten(consts)
+    carry_flat, carry_struct = jtu.tree_flatten(carry)
+    xs_flat, xs_struct = jtu.tree_flatten(xs)
 
     trace_in = (
         *consts_flat,
@@ -748,9 +759,13 @@ def _(
         *carry_flat,
         *xs_flat,
         jaxpr=quax_jaxpr,
-        num_consts=num_consts_flat,
-        num_carry=num_carry_flat,
-        **kwargs,
+        **scan_bind_params(
+            kwargs,
+            num_consts=num_consts_flat,
+            num_carry=num_carry_flat,
+            num_xs=len(xs_flat),
+            num_ys=len(quax_jaxpr.out_avals) - num_carry_flat,
+        ),
     )
 
     return jtu.tree_unflatten(out_struct, out_flat)

--- a/tests/unit/myarray.py
+++ b/tests/unit/myarray.py
@@ -13,7 +13,7 @@ from jaxtyping import Array, ArrayLike, Bool
 from packaging.version import Version
 
 from quax import ArrayValue, quaxify, register
-from quax._compat import JAX_GE_0_10_1, JAX_VERSION, typeof
+from quax._compat import JAX_GE_0_10_1, JAX_GE_0_11_0, JAX_VERSION, typeof
 
 
 class MyArray(ArrayValue):
@@ -1519,6 +1519,15 @@ def top_k_p(operand: MyArray, /, **kw: Any) -> list[MyArray]:
 @register(lax.transpose_p)
 def transpose_p(operand: MyArray, /, **kw: Any) -> MyArray:
     return replace(operand, array=lax.transpose_p.bind(operand.array, **kw))
+
+
+# ==============================================================================
+
+if JAX_GE_0_11_0:
+
+    @register(lax.unstack_p)
+    def unstack_p(x: MyArray, /, **kw: Any) -> list[MyArray]:
+        return [MyArray(y) for y in lax.unstack_p.bind(x.array, **kw)]
 
 
 # ==============================================================================

--- a/tests/unit/test_stage_value.py
+++ b/tests/unit/test_stage_value.py
@@ -5,24 +5,33 @@ from jax.custom_derivatives import SymbolicZero as SZ
 from quax._core import _DenseArrayValue, _QuaxTrace, _QuaxTracer
 
 
+# `take_current_trace` leaves the current trace unset for the duration of the
+# block, so any JAX operation inside it has no trace to bind against. Build the
+# arrays up front and keep the block down to the code actually under test.
+
+
 def test_stage_value_lifts_array_to_quaxtracer():
+    arr = jnp.array([1.0, 2.0, 3.0])
+
     with core.take_current_trace() as parent_trace:
         trace = _QuaxTrace(parent_trace, core.TraceTag())
-        arr = jnp.array([1.0, 2.0, 3.0])
         t = trace.stage_value(arr)
-        assert isinstance(t, _QuaxTracer)
-        assert isinstance(t.value, _DenseArrayValue)
-        assert jnp.array_equal(t.value.array, arr)
+
+    assert isinstance(t, _QuaxTracer)
+    assert isinstance(t.value, _DenseArrayValue)
+    assert jnp.array_equal(t.value.array, arr)
 
 
 def test_stage_value_handles_symbolic_zero():
     # SymbolicZero should be returned unchanged (JAX expects SZ handling).
+    sz = SZ(jnp.array(0.0).aval) if hasattr(SZ, "__call__") else SZ
+
     with core.take_current_trace() as parent_trace:
         trace = _QuaxTrace(parent_trace, core.TraceTag())
-        sz = SZ(jnp.array(0.0).aval) if hasattr(SZ, "__call__") else SZ
         # We expect the trace to accept SZ and return it as-is or wrapped
         # appropriately; the exact behavior is implementation defined but should
         # not raise NotImplementedError.
         res = trace.stage_value(sz)
-        # Either returns the SZ sentinel or a tracer that carries it.
-        assert res is not None
+
+    # Either returns the SZ sentinel or a tracer that carries it.
+    assert res is not None


### PR DESCRIPTION
Backport of #164 to `versions/v0.3.x`.

This branch admits JAX 0.11 (`jax>=0.5.3,!=0.7.0,!=0.7.1`, no upper bound), so it hits the same breakage as `main` did.

## Not a clean cherry-pick
The code was restructured after v0.3.x, so this needed adapting rather than picking:

| upstream (`main`) | here (`versions/v0.3.x`) |
| --- | --- |
| `src/quax/_primitives.py` | primitives live in `src/quax/_core.py` |
| `jit_quax` has the jit cache (#157-era) | pre-cache version — the `inline` fix is applied to the simpler body |
| `tests/unit/myarray.py` uses `quax.register(...)` | imports `register` directly, so `@register(...)` |
| `tests/unit/test_jit_quax_cache.py` | **not backported** — the cache it covers doesn't exist here |

The `_compat.py` helpers port over verbatim.

## The three fixes
1. **`jit_p`'s `inline` became a `jax.Inline` enum.** Enum members are always truthy, so the old `if inline:` inlined on *every* call under 0.11 — a silent behaviour change, not just a type error. Now interpreted by a new `is_early_inline` helper (`JAX_EARLY` only), keeping pre-0.11 `bool` semantics intact.
2. **`scan_p`'s parameters were reworked**: the `num_consts`/`num_carry` split became `ft_in`/`ft_out` `FlatTree` descriptors. Both the operand split and the re-bind go through `unpack_scan_args` / `scan_bind_params`, which branch on `JAX_GE_0_11_0`.
3. **New `lax.unstack_p`** registered on the `MyArray` test fixture (guarded by `JAX_GE_0_11_0`) so `lexsort`-based ops keep dispatching through Quax.

## Verified on this branch
Ran the full unit suite against both JAX lines — before/after on the version that breaks, plus a regression check on the previous one:

| | result |
| --- | --- |
| jax 0.11.0 — **before** this change | ❌ 549 failed, 372 passed |
| jax 0.11.0 — **after** | ✅ **921 passed**, 0 failed |
| jax 0.10.2 — after (regression check) | ✅ **921 passed**, 0 failed |

`ruff check` and `ruff format --check` clean on all four changed files (at this branch's pinned `v0.15.14`).

> [!NOTE]
> One adaptation worth flagging for review: the guarded `unstack_p` uses bare `@register(...)`, matching this file's existing convention. Copying upstream's `@quax.register(...)` verbatim caused a `NameError` at collection, since `myarray.py` here never imports the `quax` module.