### PR TITLE
Backport PR #166 on branch versions/v0.3.x (🐛 fix: guard TypedInt conversions on JAX 0.8.0, not 0.7.2)

### DIFF
--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -16,6 +16,7 @@ __all__ = (
     "JAX_VERSION",
     # Flags
     "JAX_GE_0_7_2",
+    "JAX_GE_0_8_0",
     "JAX_GE_0_9_2",
     "JAX_GE_0_10_1",
     "JAX_GE_0_10_2",
@@ -31,6 +32,7 @@ __all__ = (
 JAX_VERSION: Final = Version(version("jax"))
 JAX_GE_0_7_0: Final = JAX_VERSION >= Version("0.7.0")
 JAX_GE_0_7_2: Final = JAX_VERSION >= Version("0.7.2")
+JAX_GE_0_8_0: Final = JAX_VERSION >= Version("0.8.0")
 JAX_GE_0_8_2: Final = JAX_VERSION >= Version("0.8.2")
 JAX_GE_0_9_2: Final = JAX_VERSION >= Version("0.9.2")
 JAX_GE_0_10_1: Final = JAX_VERSION >= Version("0.10.1")
@@ -167,11 +169,12 @@ jax.Array.__faithful__ = True  # type: ignore[attr-defined]
 
 
 # Register plum conversions for JAX's typed literal scalars (TypedInt,
-# TypedFloat, TypedComplex). These types were introduced in JAX 0.7.2 to
+# TypedFloat, TypedComplex). These types were introduced in JAX 0.8.0 (the
+# `jax._src.literals` module exists in 0.7.2, but without the `Typed*` classes) to
 # preserve dtype information during canonicalization. They allow any library
 # using quax.ArrayValue to seamlessly handle Python scalars that JAX internally
 # represents as typed literals.
-if JAX_GE_0_7_2:
+if JAX_GE_0_8_0:
     from jax._src import literals as jax_literals
 
     @plum.conversion_method(type_from=jax_literals.TypedInt, type_to=Array)  # type: ignore[arg-type]

--- a/tests/unit/test_jax_compat.py
+++ b/tests/unit/test_jax_compat.py
@@ -8,16 +8,16 @@ import numpy as np
 import plum
 import pytest
 
-from quax._compat import JAX_GE_0_7_2
+from quax._compat import JAX_GE_0_8_0
 
 
 # Skip all tests if JAX version doesn't support TypedInt
 pytestmark = pytest.mark.skipif(
-    not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required for TypedInt"
+    not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required for TypedInt"
 )
 
 
-@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
 def test_typed_int_conversion():
     """Test that TypedInt can be converted to jax.Array."""
     from jax._src.literals import TypedInt
@@ -33,7 +33,7 @@ def test_typed_int_conversion():
     assert arr.dtype == np.int32
 
 
-@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
 def test_typed_float_conversion():
     """Test that TypedFloat can be converted to jax.Array."""
     from jax._src.literals import TypedFloat
@@ -49,7 +49,7 @@ def test_typed_float_conversion():
     assert arr.dtype == np.float32
 
 
-@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
 def test_typed_complex_conversion():
     """Test that TypedComplex can be converted to jax.Array."""
     from jax._src.literals import TypedComplex
@@ -65,7 +65,7 @@ def test_typed_complex_conversion():
     assert arr.dtype == np.complex64
 
 
-@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
 def test_typed_int_zero():
     """Test TypedInt conversion with zero value."""
     from jax._src.literals import TypedInt
@@ -77,7 +77,7 @@ def test_typed_int_zero():
     assert arr.dtype == np.int32
 
 
-@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
 def test_typed_float_negative():
     """Test TypedFloat conversion with negative value."""
     from jax._src.literals import TypedFloat
@@ -89,7 +89,7 @@ def test_typed_float_negative():
     assert arr.dtype == np.float32
 
 
-@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
 def test_typed_complex_zero():
     """Test TypedComplex conversion with zero value."""
     from jax._src.literals import TypedComplex
@@ -101,7 +101,7 @@ def test_typed_complex_zero():
     assert arr.dtype == np.complex64
 
 
-@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
 def test_typed_int_large_value():
     """Test TypedInt conversion with large value that fits in int32."""
     from jax._src.literals import TypedInt
@@ -114,7 +114,7 @@ def test_typed_int_large_value():
     assert arr.dtype == np.int32
 
 
-@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
 def test_typed_float_precision():
     """Test TypedFloat conversion preserves precision for float32."""
     from jax._src.literals import TypedFloat
@@ -127,7 +127,7 @@ def test_typed_float_precision():
     assert arr.dtype == np.float32
 
 
-@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
 def test_typed_complex_with_imaginary():
     """Test TypedComplex conversion with pure imaginary number."""
     from jax._src.literals import TypedComplex


### PR DESCRIPTION
Backport of #166 to `versions/v0.3.x` — the same mis-versioned guard is present here (near-identical `_compat.py` and an identical `test_jax_compat.py`), so this was a clean adaptation.

## The bug
`quax` can't be imported under **exactly JAX 0.7.2**:
```
AttributeError: module 'jax._src.literals' has no attribute 'TypedInt'
```
`_compat.py` gated the `Typed{Int,Float,Complex}` plum conversions behind `JAX_GE_0_7_2`, but those classes were introduced in **0.8.0** — `jax._src.literals` exists in 0.7.2 without them. 0.7.2 is the only affected version (0.7.0/0.7.1 are excluded by the project's `jax` constraint).

## The fix
Add `JAX_GE_0_8_0` and gate the conversions on it. On JAX < 0.8.0 the `Typed*` classes don't exist, so skipping the registrations is correct. `test_jax_compat.py` had the same wrong guard (its `skipif` didn't fire on 0.7.2, so it hard-failed importing `TypedInt`) — regated too.

## Verified on this branch
| JAX | result |
| --- | --- |
| 0.7.2 — before | ❌ won't import |
| 0.7.2 — after | ✅ **911 passed**, TypedInt tests skipped |
| 0.10.2 — after | ✅ the **12 TypedInt tests run and pass** |

`ruff check` + `ruff format --check` clean.

Follows #166 (main).