### PR TITLE
test: add performance benchmark harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ docs = [
 ide = ["ipykernel>=7.2.0"]
 lint = ["prek>=0.3.11", "ruff>=0.15.9"]
 tests = ["beartype>=0.20.2", "pytest>=8.3.5", "pytest-env>=1.1.5", "jax[cpu]"]
+# Performance benchmarks. Kept out of `dev`/`tests` so the default suite never
+# collects them (see tests/benchmark/conftest.py); run with
+# `uv run --group bench pytest tests/benchmark --benchmark-only`.
+bench = [{ include-group = "tests" }, "pytest-benchmark>=5.1.0"]
 
 [tool.hatch]
 build.hooks.vcs.version-file = "src/quax/_version.py"

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -1,0 +1,27 @@
+"""Keep the benchmark suite out of ordinary test runs.
+
+Benchmarks are collected only when *both*:
+
+1. ``pytest-benchmark`` is installed (the `bench` dependency group), and
+2. the invocation explicitly targets them — either the ``tests/benchmark`` path or
+   any ``--benchmark*`` flag appears on the command line.
+
+So a plain ``pytest`` / ``pytest tests`` never runs them (even if the plugin happens
+to be installed in the environment), while the intended command does:
+
+    uv run --group bench pytest tests/benchmark --benchmark-only
+"""
+
+import sys
+
+
+def _benchmarks_requested() -> bool:
+    try:
+        import pytest_benchmark  # noqa: F401
+    except ImportError:
+        return False
+    return any("benchmark" in arg for arg in sys.argv[1:])
+
+
+if not _benchmarks_requested():
+    collect_ignore_glob = ["*"]

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -13,14 +13,41 @@ to be installed in the environment), while the intended command does:
 """
 
 import sys
+from pathlib import Path
+
+
+_HERE = Path(__file__).parent.resolve()
 
 
 def _benchmarks_requested() -> bool:
+    """True only if the invocation explicitly targets the benchmark suite.
+
+    "Explicitly" means a ``--benchmark*`` flag, or a positional path pointing at
+    (or inside) this directory. A bare substring match would over-trigger — e.g.
+    ``pytest -k benchmark`` selects tests by keyword but must not pull the whole
+    benchmark suite into a normal run.
+    """
     try:
         import pytest_benchmark  # noqa: F401
     except ImportError:
         return False
-    return any("benchmark" in arg for arg in sys.argv[1:])
+
+    argv = sys.argv[1:]
+    for i, arg in enumerate(argv):
+        if arg.startswith("--benchmark"):
+            return True
+        if arg.startswith("-"):
+            continue  # an option, not a path
+        prev = argv[i - 1] if i else ""
+        if len(prev) == 2 and prev[0] == "-" and prev[1] != "-":
+            continue  # value consumed by a short option like `-k` / `-m`
+        try:
+            target = Path(arg.split("::", 1)[0]).resolve()
+        except (OSError, ValueError):
+            continue
+        if target == _HERE or _HERE in target.parents:
+            return True
+    return False
 
 
 if not _benchmarks_requested():

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -3,52 +3,53 @@
 Benchmarks are collected only when *both*:
 
 1. ``pytest-benchmark`` is installed (the `bench` dependency group), and
-2. the invocation explicitly targets them — either the ``tests/benchmark`` path or
-   any ``--benchmark*`` flag appears on the command line.
+2. the invocation explicitly targets them — either a ``--benchmark*`` flag, or a
+   positional path pointing at (or inside) this directory.
 
-So a plain ``pytest`` / ``pytest tests`` never runs them (even if the plugin happens
-to be installed in the environment), while the intended command does:
+So a plain ``pytest`` / ``pytest tests`` never runs them (even if the plugin
+happens to be installed), while the intended command does:
 
     uv run --group bench pytest tests/benchmark --benchmark-only
+
+Rather than hand-parse ``sys.argv`` (which means reasoning about which short
+options consume a value — ``-k VALUE`` does, ``-v`` does not), we use pytest's
+already-parsed positional paths (``config.args``) inside ``pytest_ignore_collect``.
 """
 
-import sys
 from pathlib import Path
 
 
 _HERE = Path(__file__).parent.resolve()
 
 
-def _benchmarks_requested() -> bool:
-    """True only if the invocation explicitly targets the benchmark suite.
-
-    "Explicitly" means a ``--benchmark*`` flag, or a positional path pointing at
-    (or inside) this directory. A bare substring match would over-trigger — e.g.
-    ``pytest -k benchmark`` selects tests by keyword but must not pull the whole
-    benchmark suite into a normal run.
-    """
-    try:
-        import pytest_benchmark  # noqa: F401
-    except ImportError:
-        return False
-
-    argv = sys.argv[1:]
-    for i, arg in enumerate(argv):
-        if arg.startswith("--benchmark"):
-            return True
-        if arg.startswith("-"):
-            continue  # an option, not a path
-        prev = argv[i - 1] if i else ""
-        if len(prev) == 2 and prev[0] == "-" and prev[1] != "-":
-            continue  # value consumed by a short option like `-k` / `-m`
+def _explicitly_targeted(config) -> bool:
+    """Whether the invocation explicitly asked for the benchmark suite."""
+    # A `--benchmark*` flag (e.g. `--benchmark-only`) always opts in.
+    if any(a.startswith("--benchmark") for a in config.invocation_params.args):
+        return True
+    # A positional path resolving to (or inside) this directory. `config.args`
+    # holds paths with options already stripped by pytest, so boolean flags like
+    # `-v` and value options like `-k VALUE` are handled correctly for free.
+    for arg in config.args:
+        path = Path(str(arg).split("::", 1)[0])
         try:
-            target = Path(arg.split("::", 1)[0]).resolve()
-        except (OSError, ValueError):
+            resolved = path.resolve()
+        except (OSError, ValueError):  # pragma: no cover - defensive
             continue
-        if target == _HERE or _HERE in target.parents:
+        if resolved == _HERE or _HERE in resolved.parents:
             return True
     return False
 
 
-if not _benchmarks_requested():
-    collect_ignore_glob = ["*"]
+def pytest_ignore_collect(collection_path, config):
+    """Ignore this directory's contents unless benchmarks were explicitly requested."""
+    path = Path(collection_path)
+    if path != _HERE and _HERE not in path.parents:
+        return None  # not under the benchmark directory; not our concern
+
+    try:
+        import pytest_benchmark  # noqa: F401
+    except ImportError:
+        return True  # plugin absent -> never collect benchmarks
+
+    return None if _explicitly_targeted(config) else True

--- a/tests/benchmark/test_construction.py
+++ b/tests/benchmark/test_construction.py
@@ -1,0 +1,91 @@
+"""Micro-benchmarks for the `equinox.Module` construction and trace hot paths.
+
+These isolate the costs the Module-metaclass optimisation targets:
+
+- ``_dense`` / ``_DenseArrayValue`` construction — the single hottest allocation
+  in a trace (built per primitive input and output);
+- user ``Value`` construction through ``_FastModuleMeta``, for both a
+  dataclass-generated ``__init__`` and a custom ``__init__`` with
+  ``__check_init__``;
+- eager ``quaxify`` trace time over a multi-primitive chain, which exercises
+  construction, dispatch, and the ``aval``/``materialise`` call paths together.
+"""
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+import quax
+from quax._compat import typeof
+from quax._values import _dense, _DenseArrayValue
+
+from ..unit.myarray import MyArray
+
+
+_arr = jnp.arange(64.0)
+
+
+class _CustomInit(quax.ArrayValue):
+    """A Value with a custom __init__ and a __check_init__ invariant."""
+
+    data: jax.Array
+    scale: float = eqx.field(static=True)
+
+    def __init__(self, data, scale=2.0):
+        self.data = jnp.asarray(data)
+        self.scale = scale
+
+    def __check_init__(self):
+        if self.scale <= 0:
+            raise ValueError("scale must be positive")
+
+    def materialise(self):
+        return self.data * self.scale
+
+    def aval(self):
+        return typeof(self.data)
+
+
+@pytest.mark.benchmark(group="construction")
+def test_construct_dense_factory(benchmark):
+    """Internal fast-path allocation (``_dense``) — bypasses the metaclass."""
+    benchmark(_dense, _arr)
+
+
+@pytest.mark.benchmark(group="construction")
+def test_construct_dense_value(benchmark):
+    """Direct ``_DenseArrayValue(...)`` construction (through the metaclass)."""
+    benchmark(_DenseArrayValue, _arr)
+
+
+@pytest.mark.benchmark(group="construction")
+def test_construct_user_dataclass_init(benchmark):
+    """User ``Value`` with a converter and dataclass-generated ``__init__``."""
+    benchmark(MyArray, _arr)
+
+
+@pytest.mark.benchmark(group="construction")
+def test_construct_user_custom_init(benchmark):
+    """User ``Value`` with a custom ``__init__`` and ``__check_init__``."""
+    benchmark(_CustomInit, _arr)
+
+
+# =============================================================================
+
+
+_xm = MyArray(jnp.ones(64))
+
+
+def _chain(a):
+    for _ in range(25):
+        a = a + a
+        a = a * a
+    return a
+
+
+@pytest.mark.benchmark(group="trace")
+def test_eager_quaxify_trace(benchmark):
+    """Eager ``quaxify`` over a ~100-primitive chain (pure trace/dispatch)."""
+    quax.quaxify(_chain)(_xm)  # warm any import-time caches
+    benchmark(lambda: quax.quaxify(_chain)(_xm))

--- a/tests/benchmark/test_numpy.py
+++ b/tests/benchmark/test_numpy.py
@@ -1,0 +1,139 @@
+"""Benchmark tests for quaxed functions on quantities."""
+
+from collections.abc import Callable
+from typing import Any, TypeAlias, TypedDict
+from typing_extensions import Unpack
+
+import jax
+import jax.numpy as jnp
+import pytest
+from jax._src.stages import Compiled
+
+import quax
+
+from ..unit.myarray import MyArray
+
+
+Args: TypeAlias = tuple[Any, ...]
+
+x = jnp.linspace(0, 1, 1000)
+xm = MyArray(x)
+
+
+def process_func(func: Callable[..., Any], args: Args) -> tuple[Compiled, Args]:
+    """JIT and compile the function."""
+    return jax.jit(quax.quaxify(func)), args
+
+
+class ParameterizationKWArgs(TypedDict):
+    """Keyword arguments for a pytest parameterization."""
+
+    argvalues: list[tuple[Callable[..., Any], Args]]
+    ids: list[str]
+
+
+def process_pytest_argvalues(
+    process_fn: Callable[[Callable[..., Any], Args], tuple[Callable[..., Any], Args]],
+    argvalues: list[tuple[Callable[..., Any], Unpack[tuple[Args, ...]]]],
+) -> ParameterizationKWArgs:
+    """Process the argvalues."""
+    # Get the ID for each parameterization
+    get_types = lambda args: tuple(str(type(a)) for a in args)
+    ids: list[str] = []
+    processed_argvalues: list[tuple[Compiled, Args]] = []
+
+    for func, *many_args in argvalues:
+        for args in many_args:
+            ids.append(f"{func.__name__}-{get_types(args)}")
+            processed_argvalues.append(process_fn(func, args))
+
+    # Process the argvalues and return the parameterization, with IDs
+    return {"argvalues": processed_argvalues, "ids": ids}
+
+
+funcs_and_args: list[tuple[Callable[..., Any], Unpack[tuple[Args, ...]]]] = [
+    (jnp.abs, (xm,)),
+    (jnp.acos, (xm,)),
+    (jnp.acosh, (xm,)),
+    (jnp.add, (xm, xm)),
+    (jnp.asin, (xm,)),
+    (jnp.asinh, (xm,)),
+    (jnp.atan, (xm,)),
+    (jnp.atan2, (xm, xm)),
+    (jnp.atanh, (xm,)),
+    # bitwise_and
+    # bitwise_left_shift
+    # bitwise_invert
+    # bitwise_or
+    # bitwise_right_shift
+    # bitwise_xor
+    (jnp.ceil, (xm,)),
+    (jnp.conj, (xm,)),
+    (jnp.cos, (xm,)),
+    (jnp.cosh, (xm,)),
+    (jnp.divide, (xm, xm)),
+    (jnp.equal, (xm, xm)),
+    (jnp.exp, (xm,)),
+    (jnp.expm1, (xm,)),
+    (jnp.floor, (xm,)),
+    (jnp.floor_divide, (xm, xm)),
+    (jnp.greater, (xm, xm)),
+    (jnp.greater_equal, (xm, xm)),
+    (jnp.imag, (xm,)),
+    (jnp.isfinite, (xm,)),
+    (jnp.isinf, (xm,)),
+    (jnp.isnan, (xm,)),
+    (jnp.less, (xm, xm)),
+    (jnp.less_equal, (xm, xm)),
+    (jnp.log, (xm,)),
+    (jnp.log1p, (xm,)),
+    (jnp.log2, (xm,)),
+    (jnp.log10, (xm,)),
+    (jnp.logaddexp, (xm, xm)),
+    (jnp.logical_and, (xm, xm)),
+    (jnp.logical_not, (xm,)),
+    (jnp.logical_or, (xm, xm)),
+    (jnp.logical_xor, (xm, xm)),
+    (jnp.multiply, (xm, xm)),
+    (jnp.negative, (xm,)),
+    (jnp.not_equal, (xm, xm)),
+    (jnp.positive, (xm,)),
+    (jnp.power, (xm, 2.0)),
+    (jnp.real, (xm,)),
+    (jnp.remainder, (xm, xm)),
+    (jnp.round, (xm,)),
+    (jnp.sign, (xm,)),
+    (jnp.sin, (xm,)),
+    (jnp.sinh, (xm,)),
+    (jnp.square, (xm,)),
+    (jnp.sqrt, (xm,)),
+    (jnp.subtract, (xm, xm)),
+    (jnp.tan, (xm,)),
+    (jnp.tanh, (xm,)),
+    (jnp.trunc, (xm,)),
+]
+
+
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("func", "args"), **process_pytest_argvalues(process_func, funcs_and_args)
+)
+@pytest.mark.benchmark(group="quaxed", max_time=1.0, warmup=False)
+def test_jit_compile(func, args):
+    """Test the speed of jitting a function."""
+    _ = func.lower(*args).compile()
+
+
+@pytest.mark.parametrize(
+    ("func", "args"), **process_pytest_argvalues(process_func, funcs_and_args)
+)
+@pytest.mark.benchmark(
+    group="quaxed",
+    max_time=1.0,  # NOTE: max_time is ignored
+    warmup=True,
+)
+def test_execute(func, args):
+    """Test the speed of calling the function."""
+    _ = jax.block_until_ready(func(*args))

--- a/tests/benchmark/test_numpy.py
+++ b/tests/benchmark/test_numpy.py
@@ -7,7 +7,6 @@ from typing_extensions import Unpack
 import jax
 import jax.numpy as jnp
 import pytest
-from jax._src.stages import Compiled
 
 import quax
 
@@ -20,8 +19,10 @@ x = jnp.linspace(0, 1, 1000)
 xm = MyArray(x)
 
 
-def process_func(func: Callable[..., Any], args: Args) -> tuple[Compiled, Args]:
-    """JIT and compile the function."""
+def process_func(
+    func: Callable[..., Any], args: Args
+) -> tuple[Callable[..., Any], Args]:
+    """Wrap ``func`` with ``jax.jit(quax.quaxify(...))``, ready to lower/execute."""
     return jax.jit(quax.quaxify(func)), args
 
 
@@ -40,7 +41,7 @@ def process_pytest_argvalues(
     # Get the ID for each parameterization
     get_types = lambda args: tuple(str(type(a)) for a in args)
     ids: list[str] = []
-    processed_argvalues: list[tuple[Compiled, Args]] = []
+    processed_argvalues: list[tuple[Callable[..., Any], Args]] = []
 
     for func, *many_args in argvalues:
         for args in many_args:

--- a/tests/benchmark/test_numpy.py
+++ b/tests/benchmark/test_numpy.py
@@ -122,19 +122,20 @@ funcs_and_args: list[tuple[Callable[..., Any], Unpack[tuple[Args, ...]]]] = [
     ("func", "args"), **process_pytest_argvalues(process_func, funcs_and_args)
 )
 @pytest.mark.benchmark(group="quaxed", max_time=1.0, warmup=False)
-def test_jit_compile(func, args):
-    """Test the speed of jitting a function."""
-    _ = func.lower(*args).compile()
+def test_jit_compile(benchmark, func, args):
+    """Benchmark lowering + compiling the quaxified function.
+
+    Must go through the ``benchmark`` fixture — the ``@pytest.mark.benchmark``
+    marker only configures options; only the fixture actually times and repeats
+    the call.
+    """
+    benchmark(lambda: func.lower(*args).compile())
 
 
 @pytest.mark.parametrize(
     ("func", "args"), **process_pytest_argvalues(process_func, funcs_and_args)
 )
-@pytest.mark.benchmark(
-    group="quaxed",
-    max_time=1.0,  # NOTE: max_time is ignored
-    warmup=True,
-)
-def test_execute(func, args):
-    """Test the speed of calling the function."""
-    _ = jax.block_until_ready(func(*args))
+@pytest.mark.benchmark(group="quaxed", max_time=1.0, warmup=True)
+def test_execute(benchmark, func, args):
+    """Benchmark steady-state execution of the compiled function."""
+    benchmark(lambda: jax.block_until_ready(func(*args)))

--- a/tests/benchmark/test_numpy.py
+++ b/tests/benchmark/test_numpy.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 from typing import Any, TypeAlias, TypedDict
-from typing_extensions import Unpack
 
 import jax
 import jax.numpy as jnp
@@ -35,7 +34,7 @@ class ParameterizationKWArgs(TypedDict):
 
 def process_pytest_argvalues(
     process_fn: Callable[[Callable[..., Any], Args], tuple[Callable[..., Any], Args]],
-    argvalues: list[tuple[Callable[..., Any], Unpack[tuple[Args, ...]]]],
+    argvalues: list[tuple[Callable[..., Any], Args]],
 ) -> ParameterizationKWArgs:
     """Process the argvalues."""
     # Get the ID for each parameterization
@@ -43,16 +42,15 @@ def process_pytest_argvalues(
     ids: list[str] = []
     processed_argvalues: list[tuple[Callable[..., Any], Args]] = []
 
-    for func, *many_args in argvalues:
-        for args in many_args:
-            ids.append(f"{func.__name__}-{get_types(args)}")
-            processed_argvalues.append(process_fn(func, args))
+    for func, args in argvalues:
+        ids.append(f"{func.__name__}-{get_types(args)}")
+        processed_argvalues.append(process_fn(func, args))
 
     # Process the argvalues and return the parameterization, with IDs
     return {"argvalues": processed_argvalues, "ids": ids}
 
 
-funcs_and_args: list[tuple[Callable[..., Any], Unpack[tuple[Args, ...]]]] = [
+funcs_and_args: list[tuple[Callable[..., Any], Args]] = [
     (jnp.abs, (xm,)),
     (jnp.acos, (xm,)),
     (jnp.acosh, (xm,)),

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -264,7 +264,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -371,17 +371,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -396,17 +396,17 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version == '3.11.*'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version == '3.11.*'" },
-    { name = "jedi", marker = "python_full_version == '3.11.*'" },
-    { name = "matplotlib-inline", marker = "python_full_version == '3.11.*'" },
-    { name = "pexpect", marker = "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "stack-data", marker = "python_full_version == '3.11.*'" },
-    { name = "traitlets", marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
 wheels = [
@@ -423,16 +423,16 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
 wheels = [
@@ -444,7 +444,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -459,11 +459,11 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "opt-einsum", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "opt-einsum" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/1e/267f59c8fb7f143c3f778c76cb7ef1389db3fd7e4540f04b9f42ca90764d/jax-0.6.2.tar.gz", hash = "sha256:a437d29038cbc8300334119692744704ca7941490867b9665406b7f90665cd96", size = 2334091, upload-time = "2025-06-17T23:10:27.186Z" }
 wheels = [
@@ -481,11 +481,11 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "opt-einsum", marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jaxlib", version = "0.8.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "opt-einsum" },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/82/84fd2c662e4d410a34b0402de9b56bb69d7f72d1b875c3ae0edc07df18cc/jax-0.8.1.tar.gz", hash = "sha256:e53f67b15315f5e154851a7fd77a192b59c6c75b3f7ac56e214296765391cca7", size = 2509320, upload-time = "2025-11-18T19:50:02.609Z" }
 wheels = [
@@ -500,9 +500,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/c5/41598634c99cbebba46e6777286fb76abc449d33d50aeae5d36128ca8803/jaxlib-0.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4601b2b5dc8c23d6afb293eacfb9aec4e1d1871cb2f29c5a151d103e73b0f8", size = 54298019, upload-time = "2025-06-17T23:10:36.916Z" },
@@ -536,9 +536,9 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/8b/9babcf487c6f1b533bca9611124c4d9593367c058a96d326c7e70db7d334/jaxlib-0.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:865add56139883405f3f15c9b0de6a64ab8f4aa549dff196b72dbc86be6ccc1f", size = 55719927, upload-time = "2025-11-18T19:48:42.679Z" },
@@ -1251,9 +1251,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "beartype", marker = "python_full_version < '3.14'" },
-    { name = "rich", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "beartype" },
+    { name = "rich" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/49/1da3299aceee66bb48e8f89b85d4a5af95ac863df39c2c295a1a238c91fc/plum_dispatch-2.6.0.tar.gz", hash = "sha256:09367134541a05f965e3f58c191f4f45b91ef1d87613835171790617bb87ce6d", size = 35394, upload-time = "2025-10-28T13:05:58.358Z" }
 wheels = [
@@ -1268,9 +1268,9 @@ resolution-markers = [
     "python_full_version >= '3.14'",
 ]
 dependencies = [
-    { name = "beartype", marker = "python_full_version >= '3.14'" },
-    { name = "rich", marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "beartype" },
+    { name = "rich" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1b/b7/84146ae5ff6c40d11357acdb36aafe3db7e104de01c1026d8e1b0ce3e7f1/plum_dispatch-2.9.0.tar.gz", hash = "sha256:fb45c5b2dd4dadd57def51bcf321dfa3a258df5c725f43adea7e7f6db3b79b52", size = 244502, upload-time = "2026-04-28T08:38:34.442Z" }
 wheels = [
@@ -1372,6 +1372,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1418,6 +1427,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]
@@ -1608,6 +1630,14 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+bench = [
+    { name = "beartype" },
+    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jax", version = "0.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pytest" },
+    { name = "pytest-benchmark" },
+    { name = "pytest-env" },
+]
 dev = [
     { name = "beartype" },
     { name = "hippogriffe" },
@@ -1655,6 +1685,13 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+bench = [
+    { name = "beartype", specifier = ">=0.20.2" },
+    { name = "jax", extras = ["cpu"] },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-benchmark", specifier = ">=5.1.0" },
+    { name = "pytest-env", specifier = ">=1.1.5" },
+]
 dev = [
     { name = "beartype", specifier = ">=0.20.2" },
     { name = "hippogriffe", specifier = "==0.2.2" },
@@ -1869,7 +1906,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -1931,7 +1968,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Adds a `pytest-benchmark` harness under `tests/benchmark/` to measure the Module-construction and trace hot paths, so the performance work can be tracked with before/after numbers.

> **Stacked on #168** — the construction micro-benchmarks import `_dense` from that PR. Base will retarget to `main` once #168 merges.

### Details

- New **`bench` dependency group** (`pytest-benchmark`), deliberately kept out of `dev`/`tests` so the default suite never installs or collects benchmarks.
- **`tests/benchmark/conftest.py`** gates collection: benchmarks are collected only when the plugin is present *and* the invocation explicitly targets them (the `tests/benchmark` path or a `--benchmark*` flag). A plain `pytest` / `pytest tests` never runs them, even if the plugin happens to be installed.
- **`test_numpy.py`** — jit-compile and execute timings across ~55 `jnp` ops on a Quax `MyArray`.
- **`test_construction.py`** — micro-benchmarks isolating the paths the fast-construction work targets: the `_dense` factory, `_DenseArrayValue`, dataclass- vs custom-init user `Value`s, and an eager quaxify chain.

Run with:

```
uv run --group bench pytest tests/benchmark --benchmark-only
```

**Note:** absolute trace-time numbers are inflated by the project's default beartype/jaxtyping runtime checking and `JAX_CHECK_TRACER_LEAKS=1` (pytest_env); they are valid for relative before/after comparison. Real-world figures in #168 come from uninstrumented profiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)