### PR TITLE
🐛 fix: raise TypeError on a dispatch miss instead of `assert False`

### DIFF
--- a/src/quax/_dispatch.py
+++ b/src/quax/_dispatch.py
@@ -105,7 +105,18 @@ def _default_process(
                     f"process rules."
                 )
         elif not eqx.is_array_like(x):
-            assert False
+            # Operand is neither a quax Value nor array-like: a genuine dispatch
+            # miss (e.g. a str/None passed to an operator). Raise a proper
+            # TypeError so callers can catch it and defer -- e.g. return
+            # NotImplemented from an operator. A bare `assert False` here
+            # surfaced as AssertionError on older jax (which routes such operands
+            # through this path) and, under `python -O`, vanished entirely,
+            # letting the bad operand fall through to the default rule.
+            raise TypeError(
+                f"Primitive {primitive} got an operand of type "
+                f"{type(x).__name__!r} that is neither a quax.Value nor "
+                f"array-like; quax has no rule for it."
+            )
 
     if default is None:
         default = value_default

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -154,3 +154,28 @@ def test_quax_tracer_aval_cached():
     assert call_count == 1, (
         f"aval() should not be called again after construction, got {call_count}"
     )
+
+
+def test_default_process_rejects_non_array_operand(monkeypatch):
+    """A non-array, non-Value operand is a dispatch miss -> TypeError.
+
+    Older jax routes such operands (e.g. a str passed to an operator) through
+    ``_default_process``, which must raise a catchable ``TypeError`` -- so a
+    caller can return ``NotImplemented`` -- rather than a bare ``AssertionError``
+    (which also vanishes under ``python -O``). Called directly so the check is
+    exercised on every jax version; newer jax rejects the operand earlier,
+    before quax is consulted.
+
+    quax's own test config runtime-typechecks ``_default_process`` (via
+    ``--jaxtyping-packages=quax,beartype``), which would reject the non-array
+    operand at the parameter boundary before this branch runs. Disable that
+    checking so the call takes the production path, where it is off.
+    """
+    import jaxtyping
+
+    from quax._dispatch import _default_process
+
+    monkeypatch.setattr(jaxtyping.config, "jaxtyping_disable", True)
+
+    with pytest.raises(TypeError, match="neither a quax.Value nor"):
+        _default_process(lax.add_p, ["not-an-array"], {})


### PR DESCRIPTION
## Problem
`_default_process` ends its operand loop with a bare `assert False`:

```python
for x in values:
    if isinstance(x, Value):
        ...
    elif not eqx.is_array_like(x):
        assert False   # operand is neither a Value nor array-like
```

That branch is a **genuine dispatch miss** — an operand quax has no rule for, e.g. a `str` or `None` passed to an operator. Reporting it via `assert False` is wrong in two ways:

1. **It surfaces as `AssertionError`.** On **jax < 0.9.2**, an unhandled operand is routed through this path, so the miss raises `AssertionError`. Callers that intend to catch a dispatch miss and defer — e.g. returning `NotImplemented` from `__add__`/`__eq__` so Python tries the reflected operand — guard on `TypeError` / `NotFoundLookupError` and therefore *miss* it, so the operator raises instead of deferring. jax ≥ 0.9.2 masks the problem by rejecting the operand with a `TypeError` before quax is consulted, which is why it goes unnoticed on recent jax.
2. **It vanishes under `python -O`.** With assertions stripped, the loop falls through and the bad operand reaches the default rule instead of being reported at all.

This is exactly what bit downstream [`quax-blocks`](https://github.com/GalacticDynamics/quax-blocks): at its dependency floor the `Lax*` operators raised `AssertionError` rather than returning `NotImplemented`, and it needed a version-gated shim to catch `AssertionError` on old jax as a workaround.

## Fix
Replace the `assert False` with a descriptive `TypeError` naming the primitive and the offending operand type:

```python
elif not eqx.is_array_like(x):
    raise TypeError(
        f"Primitive {primitive} got an operand of type "
        f"{type(x).__name__!r} that is neither a quax.Value nor "
        f"array-like; quax has no rule for it."
    )
```

Now a dispatch miss is consistently a catchable `TypeError` across every jax version and under `-O`. Downstream libraries can drop their `AssertionError` workarounds once this ships.

## Test
Adds `test_default_process_rejects_non_array_operand`. The branch is only reachable with jaxtyping runtime checking **off** — quax's own test config (`--jaxtyping-packages=quax,beartype`) type-checks the `values` parameter and would reject the non-array operand at the boundary first, whereas production callers don't run that check. The test disables jaxtyping checking (via `jaxtyping.config`, `monkeypatch`-scoped) so it exercises the production path deterministically on every jax version.

## Verified
- new test passes both with and without quax reinstalled (i.e. whether or not the beartype hook wraps `_default_process`)
- full unit suite: 952 passed, 132 skipped, 56 xfailed
- `ruff check` / `ruff format` clean; `pyright` 0 errors
