### PR TITLE
ci: track benchmark performance with CodSpeed

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,47 @@
+name: CodSpeed
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  benchmarks:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Install
+        run: uv sync --no-default-groups --group bench --locked
+
+      # Only the pure-Python construction/trace benchmarks run under CodSpeed's
+      # (valgrind-based) instrumentation mode — that is exactly the quax dispatch
+      # overhead we want to track, and it is deterministic. The `test_numpy.py`
+      # jit-compile/execute benchmarks are XLA-heavy and impractical under valgrind;
+      # they remain for local `pytest tests/benchmark --benchmark-only`.
+      - name: Run benchmarks under CodSpeed
+        uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
+        with:
+          mode: instrumentation
+          run: uv run --frozen pytest tests/benchmark/test_construction.py --codspeed
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -35,13 +35,13 @@ jobs:
         run: uv sync --no-default-groups --group bench --locked
 
       # Only the pure-Python construction/trace benchmarks run under CodSpeed's
-      # (valgrind-based) instrumentation mode — that is exactly the quax dispatch
+      # (valgrind-based) simulation mode — that is exactly the quax dispatch
       # overhead we want to track, and it is deterministic. The `test_numpy.py`
       # jit-compile/execute benchmarks are XLA-heavy and impractical under valgrind;
       # they remain for local `pytest tests/benchmark --benchmark-only`.
       - name: Run benchmarks under CodSpeed
         uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
         with:
-          mode: instrumentation
+          mode: simulation
           run: uv run --frozen pytest tests/benchmark/test_construction.py --codspeed
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,14 @@ ide = ["ipykernel>=7.2.0"]
 lint = ["prek>=0.3.11", "ruff>=0.15.9"]
 tests = ["beartype>=0.20.2", "pytest>=8.3.5", "pytest-env>=1.1.5", "jax[cpu]"]
 # Performance benchmarks. Kept out of `dev`/`tests` so the default suite never
-# collects them (see tests/benchmark/conftest.py); run with
-# `uv run --group bench pytest tests/benchmark --benchmark-only`.
-bench = [{ include-group = "tests" }, "pytest-benchmark>=5.1.0"]
+# collects them (see tests/benchmark/conftest.py). Run locally with
+# `uv run --group bench pytest tests/benchmark --benchmark-only`; CI runs them
+# under CodSpeed with `pytest tests/benchmark --codspeed`.
+bench = [
+  { include-group = "tests" },
+  "pytest-benchmark>=5.1.0",
+  "pytest-codspeed>=3.1.0",
+]
 
 [tool.hatch]
 build.hooks.vcs.version-file = "src/quax/_version.py"

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -2,14 +2,16 @@
 
 Benchmarks are collected only when *both*:
 
-1. ``pytest-benchmark`` is installed (the `bench` dependency group), and
-2. the invocation explicitly targets them — either a ``--benchmark*`` flag, or a
-   positional path pointing at (or inside) this directory.
+1. a benchmark plugin (``pytest-benchmark`` or ``pytest-codspeed``, from the `bench`
+   dependency group) is installed, and
+2. the invocation explicitly targets them — a ``--benchmark*`` flag, ``--codspeed``,
+   or a positional path pointing at (or inside) this directory.
 
-So a plain ``pytest`` / ``pytest tests`` never runs them (even if the plugin
-happens to be installed), while the intended command does:
+So a plain ``pytest`` / ``pytest tests`` never runs them (even if a plugin happens
+to be installed), while the intended commands do:
 
-    uv run --group bench pytest tests/benchmark --benchmark-only
+    uv run --group bench pytest tests/benchmark --benchmark-only   # local
+    uv run --group bench pytest tests/benchmark --codspeed         # CodSpeed CI
 
 Rather than hand-parse ``sys.argv`` (which means reasoning about which short
 options consume a value — ``-k VALUE`` does, ``-v`` does not), we use pytest's
@@ -22,10 +24,22 @@ from pathlib import Path
 _HERE = Path(__file__).parent.resolve()
 
 
+def _benchmark_plugin_available() -> bool:
+    """Whether a plugin providing the ``benchmark`` fixture is installed."""
+    for plugin in ("pytest_benchmark", "pytest_codspeed"):
+        try:
+            __import__(plugin)
+            return True
+        except ImportError:
+            continue
+    return False
+
+
 def _explicitly_targeted(config) -> bool:
     """Whether the invocation explicitly asked for the benchmark suite."""
-    # A `--benchmark*` flag (e.g. `--benchmark-only`) always opts in.
-    if any(a.startswith("--benchmark") for a in config.invocation_params.args):
+    # A `--benchmark*` flag (pytest-benchmark) or `--codspeed` (CodSpeed) opts in.
+    args = config.invocation_params.args
+    if any(a.startswith("--benchmark") or a == "--codspeed" for a in args):
         return True
     # A positional path resolving to (or inside) this directory. `config.args`
     # holds paths with options already stripped by pytest, so boolean flags like
@@ -47,9 +61,7 @@ def pytest_ignore_collect(collection_path, config):
     if path != _HERE and _HERE not in path.parents:
         return None  # not under the benchmark directory; not our concern
 
-    try:
-        import pytest_benchmark  # noqa: F401
-    except ImportError:
-        return True  # plugin absent -> never collect benchmarks
+    if not _benchmark_plugin_available():
+        return True  # no benchmark plugin -> never collect benchmarks
 
     return None if _explicitly_targeted(config) else True

--- a/tests/benchmark/test_numpy.py
+++ b/tests/benchmark/test_numpy.py
@@ -119,7 +119,7 @@ funcs_and_args: list[tuple[Callable[..., Any], Args]] = [
 @pytest.mark.parametrize(
     ("func", "args"), **process_pytest_argvalues(process_func, funcs_and_args)
 )
-@pytest.mark.benchmark(group="quaxed", max_time=1.0, warmup=False)
+@pytest.mark.benchmark(group="quaxed")
 def test_jit_compile(benchmark, func, args):
     """Benchmark lowering + compiling the quaxified function.
 
@@ -133,7 +133,7 @@ def test_jit_compile(benchmark, func, args):
 @pytest.mark.parametrize(
     ("func", "args"), **process_pytest_argvalues(process_func, funcs_and_args)
 )
-@pytest.mark.benchmark(group="quaxed", max_time=1.0, warmup=True)
+@pytest.mark.benchmark(group="quaxed")
 def test_execute(benchmark, func, args):
     """Benchmark steady-state execution of the compiled function."""
     benchmark(lambda: jax.block_until_ready(func(*args)))

--- a/uv.lock
+++ b/uv.lock
@@ -1443,6 +1443,43 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-codspeed"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/b4/cf932fcd1960a2fd6d9b09eb403253a8709aeee975961afa6299239a830e/pytest_codspeed-5.0.3.tar.gz", hash = "sha256:91afef90e6a96b013495e4702ef5d6358614a449e71008cdc194ef668778b92f", size = 324571, upload-time = "2026-05-22T16:20:49.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/f5/a8f70147216e4b84046ca406d03ecc8e83e3ea56ba1bdca0bb79cca79fee/pytest_codspeed-5.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:005348ea52ace3ede2e2f595913912ad2564cca7b124211a88dc78a9cb1fca63", size = 366249, upload-time = "2026-05-22T16:20:39.985Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/bd/7a4dbcf457fcc3ed788c55d402f3af2671e0e342b6098090fd590aa8712e/pytest_codspeed-5.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbe6a4a00b449b6ba2771f644cbc38bdf55acf5c812e60e5659110e19dd9f510", size = 932229, upload-time = "2026-05-22T16:20:37.283Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e1/414ea4c66559f24ec06aeb6db62bfc7079582dac1452e648affe1eb5cfb4/pytest_codspeed-5.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ac4344f34bbcdd17f6f8c30dbac3da2f80d223dd112e568fd7f7c2cd4cbc693", size = 934647, upload-time = "2026-05-22T16:20:31.997Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ef/32ce60d42a4aa43e728d988e13eb6568fbc7b10a514517b459bafd3f2b94/pytest_codspeed-5.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f56d0339cd98d26f6e561987be25bdd2761a5d53d8f73493b1ebe02d0d451093", size = 366253, upload-time = "2026-05-22T16:21:10.013Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/15/c66ef90a793c5d2c039e63a1726a5e55c678be2618b0f5f1660d0f79e25f/pytest_codspeed-5.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c682f6645d4eb472f3bd95dbda1805e3af4243610572cb7d6bf94a88e8a0b6c", size = 932465, upload-time = "2026-05-22T16:20:34.265Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7b/d231279301967f05b7909160489e85ee3a1b9da76094ea25343faba1abc2/pytest_codspeed-5.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f852bee785a7a124cb1720b1915670c6742af87747dc4d838f3ffdbd365ce9d9", size = 934925, upload-time = "2026-05-22T16:20:47.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/22/456c48160b761d5028c8afa119f085a9fc42855a783a13d73918078969f0/pytest_codspeed-5.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2eeb25fb1ac3f73c4de50e739e78fea396b89782bdb740bf2a7cd2df21f8d4ee", size = 366255, upload-time = "2026-05-22T16:20:56.214Z" },
+    { url = "https://files.pythonhosted.org/packages/74/33/ac7441fa937c9d9f158083a8c46920a5a5c81ed3c5f96240fc8d650db5c2/pytest_codspeed-5.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73c5c9d98a3372a42611989ccfa437cce3842431ac6d6b9ab42c4f0e59c070f7", size = 932325, upload-time = "2026-05-22T16:21:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bc/8b994adcb9e9016e7d9a808056a3dd9cca21441e432ef456eae2b697d7fe/pytest_codspeed-5.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2e0ab65df73e837666d12357280ca50ff6d6ac03ea5266703be518b68170edf", size = 934885, upload-time = "2026-05-22T16:21:01.444Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8e/e032451e9e0a06b0c4bff53105f62b693d9a54595dd8c024693741ce3380/pytest_codspeed-5.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6524c57fec279a22ffef6112af404036afc71b4704758ae9f0abda429b8478d4", size = 366253, upload-time = "2026-05-22T16:20:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7b/ae76fd8ac656b9695806a6aafd5f22ec32e6ce20e266a58f9112e01d3cd8/pytest_codspeed-5.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c383c9121deb58a69f174188e9e4488ffc0daced0ed276abf87747182511901", size = 932360, upload-time = "2026-05-22T16:20:30.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4a/dfd43d943fdb143be4fd62f34c2793ba349dc27aa188e521d19d629aa7ab/pytest_codspeed-5.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4bcdb4b6522738152885ef067e0c8524d5699828d780fb6f464cdb3db44369c", size = 934928, upload-time = "2026-05-22T16:20:38.62Z" },
+    { url = "https://files.pythonhosted.org/packages/04/6a/fdcec19c7f267c195f147c51d3fd2245f6b8d09b80495ed0a90c008e0842/pytest_codspeed-5.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:25464363c7f9b9bd5022e969c0addba616fa40ac9b8f0fc9e030c4538863b32d", size = 366259, upload-time = "2026-05-22T16:21:06.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/96/c6b03b81dcd21ae3d6b32cca0b3c10149fa378eb21b338d4b63c9eb8050b/pytest_codspeed-5.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efd43f82ea03ced8488a767ded9473f050791ab7783ea8654107e1e0ac66af40", size = 932395, upload-time = "2026-05-22T16:21:04.804Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/56ad8f1cc7d6962f8a680141b361e93467a2abc53d976cd9d5e1edd740e3/pytest_codspeed-5.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:782f9985b6f6b45b8bc20152d206d3a52b56dd088ba81cb70a71f0b39841be9e", size = 934994, upload-time = "2026-05-22T16:20:28.809Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/54/9096c4545f09da94b1b00f3be2fe4952949e86c9bcafca9a29b26aed1a75/pytest_codspeed-5.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9aa0815b90196f3c20d736ea8691381e97f12bbe8c7d87af10a351e434b452cb", size = 366311, upload-time = "2026-05-22T16:20:41.791Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/3c/24c53f67a38ad48cb087105ac30a8aa0923223ee274ea9bf2dc705edaa59/pytest_codspeed-5.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85505c96a3477c346ec2d2b7dced8478f4c651e2b1666ee102d53a832b511853", size = 933169, upload-time = "2026-05-22T16:20:43.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/de/2213f868fa7694f743f96cccbc07e757f45c920c523cccc2da97bc8652df/pytest_codspeed-5.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20eba63765be9d1b6cacbbfad84b87d49eb04b357a7045a0899880da181f81e3", size = 935522, upload-time = "2026-05-22T16:21:03.398Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/5dfea1c031d6cccc11653464828edf205c30f798caf5b2a85375aacd914a/pytest_codspeed-5.0.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:ec9fa6f0af0a9feb0e0bd517fb59ef28f806fbd50c0c6900ac26cbb4d080eba5", size = 366275, upload-time = "2026-05-22T16:20:59.463Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2b/af4d1b612f03b98a6cf3c7d5f62678917a60110a8bf380d49ab408b31137/pytest_codspeed-5.0.3-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8df77b3409f54f4a268f77f3ff74992fe1d995cdbaf2cecf8ad74d32db217ce7", size = 932537, upload-time = "2026-05-22T16:20:54.945Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a2/c7ec45e36a61b418efb2a3cccaa67a0c2fcf1f21d5880f64c33114f0c249/pytest_codspeed-5.0.3-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5d8695a227ea1c3a41d25db5b3fe720bf1b4808bd38862be811a4efd902c792", size = 934153, upload-time = "2026-05-22T16:21:07.494Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c7/d5bada9618a0af56a5c8065fc61280849cab8e7c1e24025807a51c3157ce/pytest_codspeed-5.0.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bf4cc4178cbace8f4d2bd240408276bc4da3850ac5fcb5fb5f8a74ab417615bb", size = 366339, upload-time = "2026-05-22T16:20:51.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/fb27aeb40a81320e7349553b877a21333c897b27c8dfe215630452908f36/pytest_codspeed-5.0.3-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abe793da40f87295d33988673d34f06ea569848b44490b847552cd416816258a", size = 933055, upload-time = "2026-05-22T16:20:44.861Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d9/6f2d69e96deaf0475a695fc9195af59e7a3b5fab50782855e65c63a7bc28/pytest_codspeed-5.0.3-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3a9ed38dfa776443b86f4b49a982e8443d0953db4974bd2673d63cc904ae1ad", size = 934481, upload-time = "2026-05-22T16:20:58.264Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b2/1d2a993c532146dce9eca5b5942d51898021c3579ce18b2454f932a915f8/pytest_codspeed-5.0.3-py3-none-any.whl", hash = "sha256:fe2ea83c924c2250675b75686c3ee456b8cf0208d83d552e182a195fdf467378", size = 74033, upload-time = "2026-05-22T16:20:26.814Z" },
+]
+
+[[package]]
 name = "pytest-env"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1636,6 +1673,7 @@ bench = [
     { name = "jax", version = "0.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
+    { name = "pytest-codspeed" },
     { name = "pytest-env" },
 ]
 dev = [
@@ -1690,6 +1728,7 @@ bench = [
     { name = "jax", extras = ["cpu"] },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
+    { name = "pytest-codspeed", specifier = ">=3.1.0" },
     { name = "pytest-env", specifier = ">=1.1.5" },
 ]
 dev = [


### PR DESCRIPTION
Wires the existing benchmark harness (`tests/benchmark`, added in #169) to [CodSpeed](https://codspeed.io) so performance regressions are caught per-PR.

## Changes

- **`pytest-codspeed`** added to the `bench` group, alongside `pytest-benchmark`. They coexist: `--benchmark-only` drives pytest-benchmark (local statistical runs), `--codspeed` drives pytest-codspeed (CI). Verified both locally.
- **Collection gate** (`tests/benchmark/conftest.py`) now recognises `--codspeed` and either plugin, so `pytest tests/benchmark --codspeed` collects while a plain `pytest tests` still ignores the suite.
- **Marker cleanup**: dropped the pytest-benchmark-only `max_time`/`warmup` kwargs from `test_numpy` (pytest-codspeed rejects `warmup`); `group="quaxed"` is kept and works in both plugins.
- **Workflow** `.github/workflows/codspeed.yml`: runs the pure-Python construction / eager-trace benchmarks (`test_construction.py`) under CodSpeed **instrumentation** mode on every PR and push to main.

## Scope decision

Only `test_construction.py` runs under CodSpeed. Those benchmarks (`_dense`/`_DenseArrayValue`/user-`Value` construction, and an eager quaxify trace) are pure-Python and deterministic — exactly the dispatch/construction overhead the perf work targets, and ideal for valgrind-based instrumentation. The `test_numpy.py` jit-compile/execute benchmarks are XLA-heavy and impractical under valgrind, so they stay for local `pytest tests/benchmark --benchmark-only` (and could be added later under CodSpeed *walltime* on macro runners).

## Setup required before this reports results

- Connect the repo in CodSpeed (the CodSpeed GitHub App), and/or
- add a `CODSPEED_TOKEN` repository secret.

Until then the workflow runs but has nothing to upload to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)