### PR TITLE
perf: stop rebuilding _Quaxify on every inlined pjit

### DIFF
--- a/src/quax/_primitives.py
+++ b/src/quax/_primitives.py
@@ -41,7 +41,11 @@ def jit_quax(
     # Early inline: JAX has already decided to inline the body — just re-quaxify
     # and interpret it directly without the jax.jit wrapper overhead.
     if is_early_inline(inline):
-        return quaxify(jexc.jaxpr_as_fun(jaxpr))(*args)
+        # Construct `_Quaxify` directly rather than via `quaxify()`: this runs on
+        # every inlined pjit in a quaxified trace, and `quaxify()`'s
+        # `module_update_wrapper` (which only exists to copy __wrapped__/__doc__
+        # for user introspection) is pure overhead for this transient wrapper.
+        return _Quaxify(jexc.jaxpr_as_fun(jaxpr), True, dynamic=False)(*args)
 
     leaves, treedef = jtu.tree_flatten(args)  # remove all Values
 

--- a/src/quax/_quaxify.py
+++ b/src/quax/_quaxify.py
@@ -7,6 +7,7 @@ import jax._src.core as core
 import jax.tree_util as jtu
 from jaxtyping import PyTree
 
+from ._module import _FastModuleMeta
 from ._trace import _QuaxTrace, _unwrap_tracer, _wrap_tracer
 from ._values import _is_value, CT
 
@@ -40,7 +41,11 @@ def _partition_and_wrap(tree: Any, filter_spec: Any, trace: _QuaxTrace) -> Any:
     return eqx.combine(dynamic, static, is_leaf=_is_value)
 
 
-class _Quaxify(eqx.Module, Generic[CT]):
+class _Quaxify(eqx.Module, Generic[CT], metaclass=_FastModuleMeta):
+    # `_Quaxify` is re-constructed on the hot path: every inlined `pjit` in a
+    # quaxified trace makes `jit_quax` build a fresh one (see `_primitives.py`).
+    # Using the fast metaclass skips equinox's per-instance validation (the
+    # `dir(self)` scan etc.), which otherwise costs ~40 µs per construction.
     fn: CT
     filter_spec: PyTree[bool | Callable[[Any], bool]]
     dynamic: bool = eqx.field(static=True)


### PR DESCRIPTION
## The finding

Investigating eager-path performance (the "#3" item), I decomposed `quaxify`'s per-call cost:

- **Fixed per-call overhead ≈ 10 µs** (trace setup) — negligible.
- **Per-primitive ≈ 150 µs.** And pure-JAX eager `a+b` is only **6.2 µs/op** — so quax adds **~150 µs of overhead per primitive**, a ~25× multiplier. The per-op cost is almost entirely quax machinery, not inherent JAX.

(Note: this rules out the trace-caching idea I'd floated for #3 — a transparent trace-cache is equivalent to `jax.jit`, which breaks the dynamic semantics that are the whole point of the eager path. The real lever is cutting per-op overhead.)

A profile + a metaclass spy pinned one culprit: **one slow equinox `Module` construction per op**. It's `_Quaxify` — quax's own wrapper. Whenever a quaxified trace hits an *inlined* `pjit` (which `jnp.asarray` and many jnp ops emit), `jit_quax`'s early-inline path calls `quaxify(...)`, building a fresh `_Quaxify`; and `_Quaxify` inherits `eqx.Module` directly, so it goes through equinox's *slow* metaclass (the `dir(self)` validation).

## Fix

- Give `_Quaxify` the fast metaclass (`_FastModuleMeta`) so re-construction skips the per-instance validation.
- In `jit_quax`'s early-inline path, construct `_Quaxify` directly rather than via `quaxify()`, skipping `module_update_wrapper` (it only copies `__wrapped__`/`__doc__` for introspection — pointless for a transient wrapper that's immediately called and discarded).

Together: **0 slow `_ModuleMeta.__call__` per op** (was 1).

## Measurements

| | per-op `quaxify(add)(MyArray)` | mixed add/matmul workload (wall-clock) |
|---|---:|---:|
| main | 158 µs | ~890–960 ms |
| this PR | 132 µs (**−16%**) | 763 ms (**~−15–20%**) |

The LoRA matmul benefits more (more inlined pjits). This helps broadly — any quaxified code hitting inlined pjits.

## Correctness

The inline `_Quaxify` is transient (immediately called, never flattened or introspected), so skipping `module_update_wrapper` is safe. The other `quaxify()` call sites (`while`/`scan`/`cond`, and `jit_quax`'s non-inline path) are jaxpr-cached, so they're unaffected — but they also benefit from the faster `_Quaxify` construction. Full suite: **998 passed** / 141 skipped / 56 xfailed. `ruff` + `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)