### PR TITLE
test: add eager-dispatch benchmarks + run CodSpeed clean

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -34,14 +34,25 @@ jobs:
       - name: Install
         run: uv sync --no-default-groups --group bench --locked
 
-      # Only the pure-Python construction/trace benchmarks run under CodSpeed's
-      # (valgrind-based) simulation mode — that is exactly the quax dispatch
-      # overhead we want to track, and it is deterministic. The `test_numpy.py`
-      # jit-compile/execute benchmarks are XLA-heavy and impractical under valgrind;
-      # they remain for local `pytest tests/benchmark --benchmark-only`.
+      # Run the construction/allocation micro-benchmarks and the eager-dispatch
+      # operation benchmarks (add/mul/matmul on quax Values) under CodSpeed's
+      # deterministic instrumentation mode — these capture the quax construction +
+      # dispatch overhead the perf work targets. The XLA-heavy `test_numpy.py`
+      # jit-compile/execute benchmarks are impractical under valgrind, so they stay
+      # local-only (`pytest tests/benchmark --benchmark-only`).
+      #
+      # `-o addopts=` drops the global jaxtyping/beartype runtime checking, and
+      # `-p no:env` stops pytest-env forcing `JAX_CHECK_TRACER_LEAKS=1`. Both are
+      # test-time aids that ~100x inflate and destabilise these numbers, so with
+      # them off the benchmarks measure production performance.
       - name: Run benchmarks under CodSpeed
         uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
         with:
-          mode: simulation
-          run: uv run --frozen pytest tests/benchmark/test_construction.py --codspeed
+          mode: instrumentation
+          run: >-
+            uv run --frozen pytest
+            tests/benchmark/test_construction.py
+            tests/benchmark/test_dispatch.py
+            --codspeed -o addopts= -p no:env
+          token: ${{ secrets.CODSPEED_TOKEN }}
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -55,4 +55,3 @@ jobs:
             tests/benchmark/test_dispatch.py
             --codspeed -o addopts= -p no:env
           token: ${{ secrets.CODSPEED_TOKEN }}
-          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/tests/benchmark/test_dispatch.py
+++ b/tests/benchmark/test_dispatch.py
@@ -1,0 +1,78 @@
+"""Eager (non-jit) ``quaxify`` operation benchmarks.
+
+These exercise the multiple-dispatch hot path — tracer wrapping, primitive
+processing, rule resolution, ``Value`` construction, and the inlined-``pjit``
+handling — which is what the metaclass / ABC-isinstance / inline-``pjit``
+optimisations target. Unlike the ``test_construction`` micro-benchmarks (pure
+allocation) these record end-to-end per-primitive dispatch cost, so a regression
+(or improvement) in that machinery shows up here.
+
+Small operands are used deliberately: the goal is to measure quax's Python
+overhead per primitive, not XLA throughput (pure-JAX eager ``a + b`` is ~6 µs vs
+quax's ~150 µs, so the overhead dominates at this size).
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+from jax import lax
+
+import quax
+from quax.examples import lora, zero
+
+from ..unit.myarray import MyArray
+
+
+_key = jax.random.PRNGKey(0)
+
+_xm = MyArray(jnp.arange(8.0) + 1)
+_ym = MyArray(jnp.arange(8.0) + 2)
+
+_z = zero.Zero((8,), jnp.float32)
+_arr = jnp.arange(8.0)
+
+# LoRA: a low-rank array times a dense matrix (heavy dispatch — the matmul
+# expands to several primitives, several of which are inlined pjits).
+_lora = lora.LoraArray(jax.random.normal(_key, (32, 16)), rank=4, key=_key)
+_rhs = jax.random.normal(_key, (16, 8))
+_dot_dn = (((1,), (0,)), ((), ()))
+
+
+def _bench(benchmark, fn, *args):
+    """Warm the dispatch cache, then benchmark eager ``quaxify(fn)(*args)``."""
+    qfn = quax.quaxify(fn)
+    qfn(*args)  # warm plum resolution + the dispatch cache
+    benchmark(lambda: qfn(*args))
+
+
+@pytest.mark.benchmark(group="dispatch")
+def test_add_myarray(benchmark):
+    """`quaxify(add)(MyArray, MyArray)` — the core single-primitive dispatch."""
+    _bench(benchmark, lambda a, b: a + b, _xm, _ym)
+
+
+@pytest.mark.benchmark(group="dispatch")
+def test_mul_myarray(benchmark):
+    """`quaxify(mul)(MyArray, MyArray)`."""
+    _bench(benchmark, lambda a, b: a * b, _xm, _ym)
+
+
+@pytest.mark.benchmark(group="dispatch")
+def test_add_zero(benchmark):
+    """`quaxify(add)(Zero, array)` — the symbolic-zero fast rule."""
+    _bench(benchmark, lambda a, b: a + b, _z, _arr)
+
+
+@pytest.mark.benchmark(group="dispatch")
+def test_nested_quaxify_add(benchmark):
+    """Nested `quaxify(quaxify(add))(MyArray)` — two dispatch layers."""
+    inner = quax.quaxify(lambda a, b: a + b)
+    inner(_xm, _ym)
+    benchmark(lambda: quax.quaxify(inner)(_xm, _ym))
+
+
+@pytest.mark.benchmark(group="dispatch")
+def test_matmul_lora(benchmark):
+    """`quaxify(dot_general)(LoraArray, array)` — LoRA matmul (many primitives,
+    inlined pjits)."""
+    _bench(benchmark, lax.dot_general, _lora, _rhs, _dot_dn)

--- a/tests/benchmark/test_dispatch.py
+++ b/tests/benchmark/test_dispatch.py
@@ -66,9 +66,9 @@ def test_add_zero(benchmark):
 @pytest.mark.benchmark(group="dispatch")
 def test_nested_quaxify_add(benchmark):
     """Nested `quaxify(quaxify(add))(MyArray)` — two dispatch layers."""
-    inner = quax.quaxify(lambda a, b: a + b)
-    inner(_xm, _ym)
-    benchmark(lambda: quax.quaxify(inner)(_xm, _ym))
+    outer = quax.quaxify(quax.quaxify(lambda a, b: a + b))
+    outer(_xm, _ym)  # warm both dispatch layers (plum resolution + cache)
+    benchmark(lambda: outer(_xm, _ym))
 
 
 @pytest.mark.benchmark(group="dispatch")


### PR DESCRIPTION
Follow-up to #172. As noted on #174, CodSpeed currently records **none** of the dispatch-path speedups — the workflow only ran the construction micro-benchmarks, which don't exercise the eager `quaxify` dispatch machinery that #2/#173 and #174 optimize.

## What's added

`tests/benchmark/test_dispatch.py` — eager (non-jit) `quaxify` operation benchmarks that hit the per-primitive dispatch hot path (tracer wrapping, primitive processing, rule resolution, `Value` construction, inlined-pjit handling):

- `add`/`mul` on a user `Value` (MyArray)
- `add(Zero, array)` — the symbolic-zero rule
- nested `quaxify(quaxify(add))`
- **LoRA matmul** (`dot_general` on a `LoraArray`) — the heaviest, with many inlined pjits, so it shows #174's win best

These are what record the metaclass / ABC-isinstance / inline-pjit speedups over time.

## Also: run CodSpeed *clean*

The project's pytest config turns on jaxtyping/beartype runtime checking and forces `JAX_CHECK_TRACER_LEAKS=1` (via `pytest-env`). Those are test-time correctness aids that **inflate the numbers ~100×** and would swamp any real quax change under instrumentation (and crawl under valgrind):

| `quaxify(add)(MyArray)` | instrumented (default) | clean |
|---|---:|---:|
| mean | ~20 ms | ~170 µs |

The CodSpeed step now runs with `-o addopts= -p no:env` so it measures **production** performance; this applies to the construction benchmarks too. It now runs both `test_construction.py` and `test_dispatch.py`, and the mode is corrected to `instrumentation`.

## Verification

`pytest tests/benchmark/{test_construction,test_dispatch}.py --codspeed -o addopts= -p no:env` → 10 benchmarked, all pass; clean numbers 171–384 µs (matching direct-python measurements). `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)