### PR TITLE
Backport PR #171: 🐛 fix: raise TypeError on a dispatch miss instead of `assert False`

### DIFF
--- a/src/quax/_core.py
+++ b/src/quax/_core.py
@@ -123,7 +123,18 @@ def _default_process(
             # Ignore any unwrapped _DenseArrayValues
             pass
         else:
-            assert False
+            # Operand is neither a quax Value nor array-like: a genuine dispatch
+            # miss (e.g. a str/None passed to an operator). Raise a proper
+            # TypeError so callers can catch it and defer -- e.g. return
+            # NotImplemented from an operator. A bare `assert False` here
+            # surfaced as AssertionError on older jax (which routes such operands
+            # through this path) and, under `python -O`, vanished entirely,
+            # letting the bad operand fall through to the default rule.
+            raise TypeError(
+                f"Primitive {primitive} got an operand of type "
+                f"{type(x).__name__!r} that is neither a quax.Value nor "
+                f"array-like; quax has no rule for it."
+            )
     if len(defaults) == 0:
         default = Value.default
     elif len(defaults) == 1:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -117,3 +117,28 @@ def test_default_path():
     got = quax.quaxify(lax.betainc)(jnp.array(1.0), x, y)
 
     assert jnp.array_equal(got, exp)
+
+
+def test_default_process_rejects_non_array_operand(monkeypatch):
+    """A non-array, non-Value operand is a dispatch miss -> TypeError.
+
+    Older jax routes such operands (e.g. a str passed to an operator) through
+    ``_default_process``, which must raise a catchable ``TypeError`` -- so a
+    caller can return ``NotImplemented`` -- rather than a bare ``AssertionError``
+    (which also vanishes under ``python -O``). Called directly so the check is
+    exercised on every jax version; newer jax rejects the operand earlier,
+    before quax is consulted.
+
+    quax's own test config runtime-typechecks ``_default_process`` (via
+    ``--jaxtyping-packages=quax,beartype``), which would reject the non-array
+    operand at the parameter boundary before this branch runs. Disable that
+    checking so the call takes the production path, where it is off.
+    """
+    import jaxtyping
+
+    from quax._core import _default_process
+
+    monkeypatch.setattr(jaxtyping.config, "jaxtyping_disable", True)
+
+    with pytest.raises(TypeError, match="neither a quax.Value nor"):
+        _default_process(lax.add_p, ["not-an-array"], {})


### PR DESCRIPTION
Backport of #171 to the `v0.3.x` release line.

`_default_process` ended its operand loop with a bare `assert False` when an operand is neither a `quax.Value` nor array-like — a genuine dispatch miss (e.g. a `str`/`None` passed to an operator). That:

- surfaces as `AssertionError` on jax < 0.9.2 (which routes such operands through this path), so callers that catch `TypeError`/`NotFoundLookupError` to defer (return `NotImplemented`) miss it and the operator raises instead; and
- vanishes entirely under `python -O`, letting the bad operand fall through to the default rule.

Now raises a descriptive `TypeError` naming the primitive and offending type, with a unit test exercising the branch (jaxtyping runtime checks disabled so it takes the production path).

### Backport notes
On `v0.3.x` the code predates the `_core.py` → `_dispatch.py`/`_values.py` split, so `_default_process` lives in `quax._core` — the fix and the test target that module (the test imports `from quax._core import _default_process`). The surrounding `_default_process` differs from `main` (a `defaults` set rather than the newer single-`default` form), so this was applied manually rather than cherry-picked. Only the `_default_process` `assert False` is changed, matching #171's scope.

Verified: `pytest tests/unit/test_core.py` passes (5), ruff/pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)