### PR TITLE
fix: quaxify passes through when no operand is a quax Value (#58)

### DIFF
--- a/src/quax/_quaxify.py
+++ b/src/quax/_quaxify.py
@@ -50,6 +50,18 @@ class _Quaxify(eqx.Module, Generic[CT]):
         return self.fn
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        # If nothing being quaxified is a quax Value, there is no multiple dispatch
+        # to perform, so behave exactly like `self.fn` and skip the trace entirely.
+        # Besides saving the trace overhead, this avoids wrapping plain arrays in
+        # tracers when it is pointless -- which otherwise breaks functions that read
+        # an operand concretely, e.g. `jnp.compress` reading its boolean mask (#58).
+        # Only the default `filter_spec is True` (wrap every Value) is short-cut; a
+        # custom filter_spec may deliberately pass Values through, so leave it be.
+        if self.filter_spec is True and not any(
+            _is_value(x)
+            for x in jtu.tree_leaves((self.fn, args, kwargs), is_leaf=_is_value)
+        ):
+            return self.fn(*args, **kwargs)
         tag = core.TraceTag()
         with core.take_current_trace() as parent_trace:
             trace = _QuaxTrace(parent_trace, tag)

--- a/src/quax/_quaxify.py
+++ b/src/quax/_quaxify.py
@@ -58,8 +58,7 @@ class _Quaxify(eqx.Module, Generic[CT]):
         # Only the default `filter_spec is True` (wrap every Value) is short-cut; a
         # custom filter_spec may deliberately pass Values through, so leave it be.
         if self.filter_spec is True and not any(
-            _is_value(x)
-            for x in jtu.tree_leaves((self.fn, args, kwargs), is_leaf=_is_value)
+            map(_is_value, jtu.tree_leaves((self.fn, args, kwargs), is_leaf=_is_value))
         ):
             return self.fn(*args, **kwargs)
         tag = core.TraceTag()

--- a/tests/unit/test_cache_gc.py
+++ b/tests/unit/test_cache_gc.py
@@ -15,6 +15,12 @@ import jax.numpy as jnp
 import quax
 from quax._primitives import _jit_quax_cache, _scan_quax_cache, _while_quax_cache
 
+from .myarray import MyArray
+
+
+# quaxify only traces (and thus reaches these caches) when an operand is a quax
+# Value (#58), so a `MyArray` is used to drive the jit/while paths.
+
 
 # Minimal ArrayValue with a working materialise — forces scan_quax dispatch
 # (plain JAX arrays fall through to _default_process via plum's variadic dispatch).
@@ -40,7 +46,7 @@ def test_jit_cache_uses_weakref():
         return x + 1.0
 
     before = set(_jit_quax_cache.keys())
-    quax.quaxify(inner)(jnp.array(1.0))
+    quax.quaxify(inner)(MyArray(jnp.array(1.0)))
     new_keys = set(_jit_quax_cache.keys()) - before
     assert new_keys, "Expected _jit_quax_cache to be populated"
 
@@ -63,7 +69,7 @@ def test_while_cache_uses_weakrefs():
     def f(x):
         return jax.lax.while_loop(lambda y: y < 5.0, lambda y: y + 1.0, x)
 
-    x = jnp.array(0.0)
+    x = MyArray(jnp.array(0.0))
     before = set(_while_quax_cache.keys())
     quax.quaxify(f)(x)
     new_keys = set(_while_quax_cache.keys()) - before

--- a/tests/unit/test_cache_gc.py
+++ b/tests/unit/test_cache_gc.py
@@ -18,10 +18,6 @@ from quax._primitives import _jit_quax_cache, _scan_quax_cache, _while_quax_cach
 from .myarray import MyArray
 
 
-# quaxify only traces (and thus reaches these caches) when an operand is a quax
-# Value (#58), so a `MyArray` is used to drive the jit/while paths.
-
-
 # Minimal ArrayValue with a working materialise — forces scan_quax dispatch
 # (plain JAX arrays fall through to _default_process via plum's variadic dispatch).
 class _ScanValue(quax.ArrayValue):

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -179,3 +179,18 @@ def test_default_process_rejects_non_array_operand(monkeypatch):
 
     with pytest.raises(TypeError, match="neither a quax.Value nor"):
         _default_process(lax.add_p, ["not-an-array"], {})
+
+
+# See https://github.com/nstarman/quax/issues/58
+def test_quaxify_no_values_is_passthrough():
+    """`quaxify(fn)(*args)` with no quax `Value` operands behaves exactly like
+    `fn`, without wrapping the operands in tracers.
+
+    Regression for #58: `jnp.compress` reads its boolean mask concretely, so a
+    needless tracer wrap raised `TracerBoolConversionError` even though there was
+    nothing to dispatch on.
+    """
+    xbool = jnp.array([True, False, True])
+    x1 = jnp.array([1.0, 2.0, 3.0])
+    got = quax.quaxify(jnp.compress)(xbool, x1)
+    assert jnp.array_equal(got, jnp.compress(xbool, x1))

--- a/tests/unit/test_jit_quax_cache.py
+++ b/tests/unit/test_jit_quax_cache.py
@@ -28,6 +28,14 @@ import quax
 from quax._compat import JAX_GE_0_11_0, jit_p
 from quax._primitives import _jit_quax_cache, jit_quax
 
+from .myarray import MyArray
+
+
+# quaxify short-circuits to `fn(*args)` when no operand is a quax Value (#58), so
+# the jit_quax cache — which only matters when Values flow through a `jit_p` — is
+# exercised by passing a `MyArray`. `_v` wraps a plain array as that Value.
+_v = MyArray
+
 
 def _extract_jit_jaxpr(closed_jaxpr: Any) -> Any:
     """Return the ClosedJaxpr param from the first jit_p equation, or None."""
@@ -99,7 +107,7 @@ def test_jit_quax_cache_populates_on_first_call():
     def inner(x):
         return x + 1.0
 
-    quax.quaxify(inner)(jnp.array(0.0))
+    quax.quaxify(inner)(_v(jnp.array(0.0)))
     assert len(_jit_quax_cache) > 0, "Cache was not populated on first call."
 
 
@@ -112,7 +120,7 @@ def test_jit_quax_cache_hit_same_avals():
     def inner(x):
         return x + 1.0
 
-    x = jnp.array(0.0)
+    x = _v(jnp.array(0.0))
     quax.quaxify(inner)(x)
     size_after_first = len(_jit_quax_cache)
     assert size_after_first > 0
@@ -136,7 +144,7 @@ def test_jit_quax_cache_miss_different_treedef():
     def inner_two(x, y):
         return x + y
 
-    x = jnp.array(1.0)
+    x = _v(jnp.array(1.0))
     quax.quaxify(inner_one)(x)
     quax.quaxify(inner_two)(x, x)
 
@@ -180,9 +188,9 @@ def test_jit_quax_cache_stable_while_jaxpr_alive():
     def inner(x):
         return x * 3.0
 
-    x = jnp.array(1.0)
+    x = _v(jnp.array(1.0))
     quax_fn = quax.quaxify(inner)
-    expected = float(quax_fn(x))
+    expected = float(quax_fn(x).array)
 
     keys_before = set(_jit_quax_cache.keys())
     assert keys_before, "Cache should be populated after first call."
@@ -194,7 +202,7 @@ def test_jit_quax_cache_stable_while_jaxpr_alive():
         "Cache entries were evicted while jaxpr was still reachable."
     )
 
-    assert float(quax_fn(x)) == expected
+    assert float(quax_fn(x).array) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -218,8 +226,8 @@ def test_jit_inside_jit_populates_cache():
     def outer(x):
         return inner(x)
 
-    result = quax.quaxify(outer)(jnp.array(0.0))
-    assert float(result) == 1.0  # correct answer
+    result = quax.quaxify(outer)(_v(jnp.array(0.0)))
+    assert float(result.array) == 1.0  # correct answer
 
     assert len(_jit_quax_cache) >= 2, (
         "Expected >=2 cache entries for a JIT-inside-JIT call "

--- a/tests/unit/test_jit_quax_cache.py
+++ b/tests/unit/test_jit_quax_cache.py
@@ -163,7 +163,8 @@ def test_jit_quax_cache_entry_weakref_matches_key():
     def inner(x):
         return x * 3.0
 
-    quax.quaxify(inner)(jnp.array(1.0))
+    quax.quaxify(inner)(_v(jnp.array(1.0)))
+    assert _jit_quax_cache, "Cache was not populated — nothing to check."
 
     for key, entry in _jit_quax_cache.items():
         stored_id, _treedef = key  # key is now (id(jaxpr), treedef) — no inline

--- a/tests/unit/test_numpy/test_jax_array.py
+++ b/tests/unit/test_numpy/test_jax_array.py
@@ -10,9 +10,6 @@ from quax import quaxify
 from quax._compat import JAX_VERSION
 
 
-xfail_quax58 = pytest.mark.xfail(
-    reason="https://github.com/patrick-kidger/quax/issues/58"
-)
 mark_todo = pytest.mark.skip("TODO")
 skip_removed_jax_0_10_0 = pytest.mark.skipif(
     JAX_VERSION >= Version("0.10"),
@@ -66,7 +63,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("argpartition", (x, 1), {}),
         ("argsort", (x,), {}),
         *(
-            pytest.param("argwhere", (x,), {}, marks=xfail_quax58),
+            pytest.param("argwhere", (x,), {}),
             ("argwhere", (x,), {"size": x.size}),  # TODO: not need static size
         ),
         ("around", (x,), {}),
@@ -87,9 +84,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("average", (x,), {}),
         ("bartlett", (3,), {}),
         *(
-            pytest.param(
-                "bincount", (jnp.asarray([0, 1, 1, 2, 2, 2]),), {}, marks=xfail_quax58
-            ),
+            pytest.param("bincount", (jnp.asarray([0, 1, 1, 2, 2, 2]),), {}),
             ("bincount", (jnp.asarray([0, 1, 1, 2, 2, 2]),), {"length": 3}),
         ),
         ("bitwise_and", (xbool, xbool), {}),
@@ -110,14 +105,14 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("can_cast", (x, int), {}),
         ("cbrt", (x,), {}),
         ("ceil", (x,), {}),
-        pytest.param("choose", (0, [x, x]), {}, marks=xfail_quax58),
+        pytest.param("choose", (0, [x, x]), {}),
         ("clip", (x, 1, 2), {}),
         ("column_stack", ([x, x],), {}),
         pytest.param("complex128", (1,), {}, marks=pytest.mark.xfail),
         ("complex64", (1,), {}),
         pytest.param("complex_", (1,), {}, marks=pytest.mark.xfail),
         pytest.param("complexfloating", (1,), {}, marks=pytest.mark.xfail),
-        pytest.param("compress", (xbool, x), {}, marks=xfail_quax58),
+        pytest.param("compress", (xbool, x), {}),
         ("concat", ([x, x],), {}),
         ("concatenate", ([x, x],), {}),
         ("conj", (x,), {}),
@@ -161,7 +156,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("exp2", (x,), {}),
         ("expand_dims", (x, 0), {}),
         ("expm1", (x,), {}),
-        pytest.param("extract", (jnp.array([True]), x), {}, marks=xfail_quax58),
+        pytest.param("extract", (jnp.array([True]), x), {}),
         ("eye", (2,), {}),
         ("fabs", (x,), {}),
         ("fill_diagonal", (jnp.eye(3), 2), {"inplace": False}),
@@ -172,7 +167,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
             marks=[*xfail_deprecated_jax_0_9_0, skip_removed_jax_0_10_0],
         ),
         *(
-            pytest.param("flatnonzero", (x,), {}, marks=xfail_quax58),
+            pytest.param("flatnonzero", (x,), {}),
             ("flatnonzero", (x,), {"size": x.size}),
         ),
         ("flip", (x,), {}),
@@ -227,7 +222,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("insert", (x, 1, 2.0), {}),
         ("interp", (x[:, 0], x[:, 0], 2 * x[:, 0]), {}),
         *(
-            pytest.param("intersect1d", (x[:, 0], x[:, 0]), {}, marks=xfail_quax58),
+            pytest.param("intersect1d", (x[:, 0], x[:, 0]), {}),
             ("intersect1d", (x[:, 0], x[:, 0]), {"size": x[:, 0].size}),
         ),
         ("invert", (x.astype(int),), {}),
@@ -299,7 +294,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("negative", (x,), {}),
         ("nextafter", (x, y), {}),
         *(
-            pytest.param("nonzero", (x,), {}, marks=xfail_quax58),
+            pytest.param("nonzero", (x,), {}),
             ("nonzero", (x,), {"size": x.size}),
         ),
         ("not_equal", (x, y), {}),
@@ -336,7 +331,6 @@ xbool = jnp.array([True, False, True], dtype=bool)
             "ravel_multi_index",
             (jnp.array([[0, 1], [0, 1]]), (2, 2)),
             {},
-            marks=xfail_quax58,
         ),
         ("real", (x,), {}),
         ("reciprocal", (x,), {}),
@@ -349,7 +343,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("rint", (x,), {}),
         ("roll", (x, 4), {}),
         ("rollaxis", (x, -1), {}),
-        pytest.param("roots", (x[:, 0],), {}, marks=xfail_quax58),
+        pytest.param("roots", (x[:, 0],), {}),
         ("rot90", (x,), {}),
         ("round", (x,), {}),
         # pytest.param("round_", (x,), {}, marks=pytest.mark.deprecated),
@@ -358,11 +352,11 @@ xbool = jnp.array([True, False, True], dtype=bool)
         pytest.param("searchsorted", (x,), {}, marks=mark_todo),
         pytest.param("select", (x,), {}, marks=mark_todo),
         *(
-            pytest.param("setdiff1d", (x[:, 0], y[:, 0]), {}, marks=xfail_quax58),
+            pytest.param("setdiff1d", (x[:, 0], y[:, 0]), {}),
             ("setdiff1d", (x[:, 0], y[:, 0]), {"size": x[:, 0].size}),
         ),
         *(
-            pytest.param("setxor1d", (x[:, 0], y[:, 0]), {}, marks=xfail_quax58),
+            pytest.param("setxor1d", (x[:, 0], y[:, 0]), {}),
             ("setxor1d", (x[:, 0], y[:, 0]), {"size": x[:, 0].size}),
         ),
         ("shape", (x,), {}),
@@ -401,7 +395,6 @@ xbool = jnp.array([True, False, True], dtype=bool)
                 ),
             ),
             {},
-            marks=xfail_quax58,
         ),
         ("triu", (x,), {}),
         ("triu_indices_from", (x,), {}),
@@ -409,27 +402,27 @@ xbool = jnp.array([True, False, True], dtype=bool)
         ("trunc", (x,), {}),
         pytest.param("ufunc", (x,), {}, marks=mark_todo),
         *(
-            pytest.param("union1d", (x[:, 0], y[:, 0]), {}, marks=xfail_quax58),
+            pytest.param("union1d", (x[:, 0], y[:, 0]), {}),
             ("union1d", (x[:, 0], y[:, 0]), {"size": x[:, 0].size}),
         ),
         *(
-            pytest.param("unique", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique", (x,), {}),
             ("unique", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_all", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique_all", (x,), {}),
             ("unique_all", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_counts", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique_counts", (x,), {}),
             ("unique_counts", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_inverse", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique_inverse", (x,), {}),
             ("unique_inverse", (x,), {"size": x.size}),
         ),
         *(
-            pytest.param("unique_values", (x,), {}, marks=xfail_quax58),
+            pytest.param("unique_values", (x,), {}),
             ("unique_values", (x,), {"size": x.size}),
         ),
         pytest.param(


### PR DESCRIPTION
Fixes #58.

## The bug

`quax.quaxify(jnp.compress)(mask, x)` raised `TracerBoolConversionError`. `_Quaxify.__call__` wraps every leaf of `(fn, args, kwargs)` in a tracer — even when **nothing being quaxified is a quax `Value`**. With no Value there's nothing to dispatch on, so this was pure overhead, and it broke functions that read an operand concretely: `jnp.compress` reads its boolean mask, which a tracer can't satisfy (`jax.jit(jnp.compress)` fails the same way; native `jnp.compress` on concrete arrays is fine).

## The fix

When `filter_spec is True` and no leaf is a `Value`, call `self.fn(*args, **kwargs)` directly and skip the trace. This makes `quaxify(fn)` behave **exactly like `fn`** when no quax types are involved — the documented contract.

⚠️ **Behavior change (strict improvement):** `quaxify(fn)(non_Value_args)` now runs `fn` natively instead of tracing. For the vast majority of functions the results are identical (quax already delegated plain arrays to native ops); the *difference* is that previously-broken concrete-read cases now work. There is no case that worked before and breaks now. It's also a small speedup. A custom `filter_spec` is left untouched (it may deliberately pass Values through).

## Impact on the test suite

The fix un-breaks a whole class of previously-`xfail`ed functions — **the suite went from 998 → 1018 passed** as ~19 `xfail_quax58`-marked tests now pass:

- The `xfail_quax58` marker in `test_jax_array.py` (literally named after this issue) is now obsolete — `compress`, `nonzero`, `unique*`, `argwhere`, `flatnonzero`, `intersect1d`, `setdiff1d`, `union1d`, `roots`, … all pass. Removed the marker so they run as normal regression tests.
- The `MyArray`-input versions in `test_myarray.py` **stay** `xfail`ed: a quax `Value` flowing through a concrete-reading function is a separate, still-open problem (the short-circuit only applies when there are no Values).
- The jit/while jaxpr caches are only reached when Values flow through a `jit_p`/`while_p`; `test_jit_quax_cache.py` / `test_cache_gc.py` now drive them with a `MyArray` instead of a plain array (the plain-array calls correctly short-circuit now).

Added a direct regression test (`test_quaxify_no_values_is_passthrough`). Full suite: **1018 passed**, ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)