### PR TITLE
fix: Unitful.integer_pow exponentiates the array, not just the units

### DIFF
--- a/src/quax/examples/unitful/_core.py
+++ b/src/quax/examples/unitful/_core.py
@@ -74,7 +74,7 @@ def _(x: Unitful, y: ArrayLike, /, **kw: Any) -> Unitful:
 @quax.register(jax.lax.integer_pow_p)
 def _(x: Unitful, *, y: int):
     units = {k: v * y for k, v in x.units.items()}
-    return Unitful(x.array, units)
+    return Unitful(jax.lax.integer_pow_p.bind(x.array, y=y), units)
 
 
 @quax.register(jax.lax.lt_p)

--- a/tests/usage/test_unitful.py
+++ b/tests/usage/test_unitful.py
@@ -1,0 +1,31 @@
+import jax.numpy as jnp
+
+import quax
+from quax.examples.unitful import meters, seconds, Unitful
+
+
+def test_integer_pow_exponentiates_array():
+    """`integer_pow` must raise the array to the power, not just scale the units.
+
+    Regression: the handler scaled `units` by `y` but returned `x.array`
+    unchanged, so `Unitful(a, {m: 1}) ** 2` gave the array `a` (not `a ** 2`)
+    with units `m ** 2` — a silent wrong value.
+    """
+    x = Unitful(jnp.array([2.0, 3.0]), meters)
+
+    out = quax.quaxify(lambda a: a**2)(x)
+
+    assert isinstance(out, Unitful)
+    assert out.units == {meters: 2}
+    assert jnp.array_equal(out.array, jnp.array([4.0, 9.0]))
+
+
+def test_integer_pow_units_and_values_agree():
+    """Cube a velocity-like quantity: both value and units are exponentiated."""
+    v = Unitful(jnp.array(2.0), {meters: 1, seconds: -1})
+
+    out = quax.quaxify(lambda a: a**3)(v)
+
+    assert isinstance(out, Unitful)
+    assert out.units == {meters: 3, seconds: -3}
+    assert jnp.array_equal(out.array, jnp.array(8.0))


### PR DESCRIPTION
## Summary

The `integer_pow_p` handler in the `unitful` example scaled the **units** by the exponent but returned the **array unchanged**:

```python
@quax.register(jax.lax.integer_pow_p)
def _(x: Unitful, *, y: int):
    units = {k: v * y for k, v in x.units.items()}
    return Unitful(x.array, units)   # <-- x.array never raised to the power
```

So `Unitful(a, {meters: 1}) ** 2` yielded the array `a` (not `a ** 2`) carrying units `meters ** 2` — a **silent wrong value**.

## Fix

Bind `integer_pow_p` on `x.array` so the value is exponentiated to match the units:

```python
    return Unitful(jax.lax.integer_pow_p.bind(x.array, y=y), units)
```

## Tests

The `unitful` example had no test module, so this adds `tests/usage/test_unitful.py`:
- `test_integer_pow_exponentiates_array` — `[2, 3] m` squared → `[4, 9] m²` (fails on the old code)
- `test_integer_pow_units_and_values_agree` — cubing a `m·s⁻¹` quantity exponentiates both value and units

Both fail on the pre-fix code and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)