### PR TITLE
fix: Zero strided-slice output shape (ceil, not floor)

### DIFF
--- a/src/quax/examples/zero/_core.py
+++ b/src/quax/examples/zero/_core.py
@@ -134,8 +134,12 @@ def _(operand: Zero, *indices, slice_sizes) -> Zero:
 def _(operand: Zero, *, start_indices, limit_indices, strides) -> Zero:
     if strides is None:
         strides = [1 for _ in start_indices]
+    # `len(range(...))` gives the strided-slice output length exactly, matching
+    # JAX. A plain `(limit - start) // stride` floors and is off by one whenever
+    # the span is not a multiple of the stride (e.g. start=0, limit=5, stride=2
+    # selects indices 0, 2, 4 -> length 3, not 2).
     shape = [
-        (limit - start) // stride
+        len(range(start, limit, stride))
         for start, limit, stride in zip(start_indices, limit_indices, strides)
     ]
     return Zero(tuple(shape), operand.dtype)

--- a/tests/usage/test_zero.py
+++ b/tests/usage/test_zero.py
@@ -153,6 +153,21 @@ def test_slice(getkey):
     assert eqx.tree_equal(out, zero.Zero(true_shape, jnp.float32))
 
 
+def test_strided_slice():
+    # Strides whose spans are not multiples of the stride. The output shape must
+    # match materialising then slicing, i.e. ceil((limit - start) / stride) --
+    # a plain floor division would give the wrong (off-by-one) shape here.
+    z = zero.Zero((5, 7), jnp.float32)
+
+    def f(x):
+        return lax.slice(x, (0, 1), (5, 7), (2, 3))
+
+    out = quax.quaxify(f)(z)
+    true_shape = f(jnp.zeros((5, 7), jnp.float32)).shape
+    assert true_shape == (3, 2)  # indices 0,2,4 and 1,4 -> ceil, not floor
+    assert eqx.tree_equal(out, zero.Zero(true_shape, jnp.float32))
+
+
 @pytest.mark.skip("dynamic quaxify is disabled for now")
 def test_creation():
     for maybe_jit in (jax.jit, lambda x: x):


### PR DESCRIPTION
## Summary

The `slice_p` handler in the `zero` example computed each output dimension with floor division:

```python
shape = [
    (limit - start) // stride
    for start, limit, stride in zip(start_indices, limit_indices, strides)
]
```

JAX's strided-slice length is `ceil((limit - start) / stride)`, so the shape was **off by one** whenever a span was not a multiple of its stride.

Example: `start=0, limit=5, stride=2` selects indices `0, 2, 4` → length **3**, but `(5 - 0) // 2 == 2`.

## Fix

Use `len(range(start, limit, stride))`, which is exactly the strided-slice length and provably matches JAX's semantics (no ceil arithmetic to get wrong):

```python
shape = [
    len(range(start, limit, stride))
    for start, limit, stride in zip(start_indices, limit_indices, strides)
]
```

## Test

Adds `test_strided_slice` to `tests/usage/test_zero.py`, cross-checking the `Zero` output shape against materialise-then-slice for strides whose spans aren't multiples of the stride (`(2, 3)` over a `(5, 7)` array → `(3, 2)`). Fails on the old code, passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)