### PR TITLE
chore: examples/docs cleanup (assert False, orphaned example, doc placeholder)

### DIFF
--- a/docs/api/quax.md
+++ b/docs/api/quax.md
@@ -24,4 +24,9 @@ A developer of a library built on Quax (e.g. if you wanted to write your own lib
 ::: quax.ArrayValue
     options:
         members:
-            - does_not_exit
+            - aval
+            - materialise
+            - shape
+            - dtype
+            - ndim
+            - size

--- a/src/quax/examples/__init__.py
+++ b/src/quax/examples/__init__.py
@@ -1,7 +1,15 @@
 import importlib
 
 
-__all__ = ("lora", "named", "prng", "sparse", "structured_matrices", "zero")
+__all__ = (
+    "lora",
+    "named",
+    "prng",
+    "sparse",
+    "structured_matrices",
+    "unitful",
+    "zero",
+)
 
 
 def __getattr__(name: str):

--- a/src/quax/examples/zero/_core.py
+++ b/src/quax/examples/zero/_core.py
@@ -76,7 +76,10 @@ def _to_struct(x):
     elif isinstance(x, get_args(ArrayLike)):
         return jax.ShapeDtypeStruct(jnp.shape(x), jnp.result_type(x))
     else:
-        assert False
+        raise TypeError(
+            f"Cannot convert {type(x).__name__} to a ShapeDtypeStruct; expected a "
+            "quax.ArrayValue or an array-like."
+        )
 
 
 @quax.quaxify

--- a/tests/unit/test_examples_imports.py
+++ b/tests/unit/test_examples_imports.py
@@ -2,7 +2,15 @@ import importlib
 import sys
 
 
-EXAMPLE_MODULES = ("lora", "named", "prng", "sparse", "structured_matrices", "zero")
+EXAMPLE_MODULES = (
+    "lora",
+    "named",
+    "prng",
+    "sparse",
+    "structured_matrices",
+    "unitful",
+    "zero",
+)
 
 
 def clear_examples_modules():


### PR DESCRIPTION
## Summary

Three small, verified pre-v0.4.0 cleanups (bundled).

### 1. `zero._to_struct`: `assert False` → `TypeError`
The `else` branch used `assert False`, which is stripped under `python -O` — the helper would then return `None` on unexpected input and fail confusingly downstream. Now raises a descriptive `TypeError` (same fix #171 applied to `_core.py`).

### 2. `unitful` example was orphaned
`quax.examples.__all__` omitted `"unitful"`, so it wasn't discoverable via the lazy loader / `dir()`, unlike every other example. Added it (and to the `EXAMPLE_MODULES` list in `test_examples_imports.py` so the lazy-load test actually covers it).

### 3. Broken API-doc placeholder
`docs/api/quax.md` listed a single placeholder member `does_not_exit` for `quax.ArrayValue`, so its page rendered no real methods. Now lists the actual members: `aval`, `materialise`, `shape`, `dtype`, `ndim`, `size`.

## Verification
- Full suite: **1022 passed, 141 skipped**.
- `_to_struct` raising and `unitful` lazy-load both checked directly.

## Note (out of scope, flagged separately)
`test_examples_submodules_are_lazy_loaded` is order-dependent and its premise is partly false: `quax/__init__.py` eagerly imports `lora`/`zero` via backward-compat aliases (`lora = examples.lora`), so those aren't lazy. The test only passes because `quax` is already imported earlier in a full run. This is pre-existing (fails run-alone on `main` too) and left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)