### PR TITLE
chore: export examples/lora/zero from top-level __all__

### DIFF
--- a/src/quax/__init__.py
+++ b/src/quax/__init__.py
@@ -5,6 +5,10 @@ __all__ = (
     "quaxify",
     "Value",
     "ArrayValue",
+    "examples",
+    # Backward-compatibility aliases for `examples.lora` / `examples.zero`.
+    "lora",
+    "zero",
 )
 
 import importlib.metadata


### PR DESCRIPTION
## Summary

`quax/__init__.py` exposes `quax.examples` (via an `as`-import) and the legacy `quax.lora` / `quax.zero` aliases (plain assignments), but none appeared in `__all__`. Consequences:

- `from quax import *` silently skipped them.
- Strict type checkers don't treat them as explicitly re-exported, so downstream `quax.lora.LoraArray` can trip export warnings.

Added `examples`, `lora`, `zero` to `__all__` so the declared public surface matches what's actually importable.

`lora`/`zero` are kept as-is (backward-compat aliases); this only advertises them in `__all__`, it doesn't change their eager-import behavior. That eager-import / lazy-load question is being handled separately.

## Verification
- `import quax` + all three names resolve; `quax.__all__` updated.
- ruff, pyright (pre-commit): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)