### PR TITLE
test: broaden custom_jvp coverage (mixed operands, vmap, both-argnums, output SZ)

### DIFF
--- a/tests/unit/test_custom_jvp.py
+++ b/tests/unit/test_custom_jvp.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 from jax.custom_derivatives import SymbolicZero as SZ
 
 import quax
+from quax._compat import typeof
 
 from .myarray import MyArray
 
@@ -154,3 +155,98 @@ def test_custom_jvp_symbolic_zeros_grad():
 
     assert isinstance(got_grad, MyArray)
     assert jnp.allclose(got_grad.array, expected_grad)
+
+
+# ---------------------------------------------------------------------------
+# Mixed Value / plain-array operands, batching, and multi-argument gradients
+# ---------------------------------------------------------------------------
+
+
+def test_custom_jvp_mixed_value_and_array():
+    """One MyArray operand and one plain array still dispatches through the
+    custom_jvp rule (only the all-plain case short-circuits, see #58)."""
+    x_val = jnp.array(2.0)
+    y_val = jnp.array(3.0)
+    expected = g_custom_jvp(x_val, y_val)
+
+    got = quax.quaxify(g_custom_jvp)(MyArray(x_val), y_val)
+
+    assert isinstance(got, MyArray)
+    assert jnp.allclose(got.array, expected)
+
+
+def test_custom_jvp_grad_both_argnums():
+    """jax.grad w.r.t. both arguments of a two-argument custom_jvp."""
+    x_val = jnp.array(2.0)
+    y_val = jnp.array(3.0)
+
+    def fn(x: MyArray, y: MyArray) -> jax.Array:
+        return quax.quaxify(g_custom_jvp)(x, y).array
+
+    gx, gy = jax.grad(fn, argnums=(0, 1))(MyArray(x_val), MyArray(y_val))
+
+    # d(x*y)/dx = y, d(x*y)/dy = x
+    assert isinstance(gx, MyArray) and isinstance(gy, MyArray)
+    assert jnp.allclose(gx.array, y_val)
+    assert jnp.allclose(gy.array, x_val)
+
+
+def test_custom_jvp_vmap():
+    """jax.vmap over a quaxified custom_jvp function batches correctly."""
+    xs_val = jnp.arange(3.0)
+    ys_val = jnp.arange(3.0) + 1.0
+    expected = jax.vmap(g_custom_jvp)(xs_val, ys_val)
+
+    got = jax.vmap(quax.quaxify(g_custom_jvp))(MyArray(xs_val), MyArray(ys_val))
+
+    assert isinstance(got, MyArray)
+    assert jnp.allclose(got.array, expected)
+
+
+# A custom_jvp with a second output that is constant in `x`, so its JVP rule
+# returns a SymbolicZero *output* tangent. This drives the output-symbolic-zero
+# branch in `_custom_jvp_jvp_wrap` (the SZ is turned into a concrete zero).
+@jax.custom_jvp
+def q_two_out(x: jax.Array) -> tuple[jax.Array, jax.Array]:
+    return x**2, jnp.ones(())
+
+
+def _q_two_out_jvp(primals, tangents):
+    (x,) = primals
+    (x_dot,) = tangents
+    primal_out = (x**2, jnp.ones(()))
+    tangent_out = (2 * x * x_dot, SZ(typeof(primal_out[1])))
+    return primal_out, tangent_out
+
+
+q_two_out.defjvp(_q_two_out_jvp, symbolic_zeros=True)
+
+
+def _raw(x):
+    """Unwrap a MyArray to its array; pass plain arrays through."""
+    return x.array if isinstance(x, MyArray) else x
+
+
+def test_custom_jvp_symbolic_zero_output_tangent():
+    """A JVP rule returning a SymbolicZero output tangent yields a concrete
+    zero tangent after quaxification (exercises the output-SZ branch).
+
+    The second output is constant in ``x``, so quax materialises a mismatched
+    primal/tangent pair to plain arrays -- hence values are compared without
+    assuming a MyArray wrapper.
+    """
+    x_val = jnp.array(3.0)
+    t_val = jnp.array(1.0)
+
+    expected_p, expected_t = jax.jvp(q_two_out, (x_val,), (t_val,))
+
+    primal_out, tangent_out = jax.jvp(
+        quax.quaxify(q_two_out), (MyArray(x_val),), (MyArray(t_val),)
+    )
+
+    for got, exp in zip(primal_out, expected_p, strict=True):
+        assert jnp.allclose(_raw(got), exp)
+    for got, exp in zip(tangent_out, expected_t, strict=True):
+        assert jnp.allclose(_raw(got), exp)
+    # The symbolic-zero output tangent becomes an exact concrete zero.
+    assert jnp.array_equal(_raw(tangent_out[1]), jnp.zeros(()))


### PR DESCRIPTION
## Summary

`test_custom_jvp.py` previously only covered all-`MyArray` operands with single-arg or symbolic-zero-**input** JVPs. Adds four cases for realistic, previously-untested paths:

1. **Mixed operands** — one `MyArray` + one plain array. Distinct from the existing two-`MyArray` tests; the all-plain case short-circuits (#58), so this is the mixed dispatch path.
2. **`jax.grad` w.r.t. both argnums** of a two-argument custom_jvp.
3. **`jax.vmap`** over a quaxified custom_jvp (batching was untested).
4. **Output symbolic-zero tangent** — a JVP rule returning a `SymbolicZero` *output* tangent, which drives the output-SZ branch in `_custom_jvp_jvp_wrap` (`_trace.py`) where the SZ is converted to a concrete zero. This branch had no prior coverage.

Each was validated to produce results matching the plain (non-quaxified) reference.

## Notes
- The SZ output aval is built with `quax._compat.typeof` (not `jax.typeof`, which only exists on JAX ≥0.8.2) so the fixture works across the whole supported range down to the 0.7.2 floor.
- Verified passing both with jaxtyping/beartype enabled (as CI runs) and disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)