### PR TITLE
fix: _jit_quax_cache no longer pins the jaxpr its weakref watches (unbounded growth)

### DIFF
--- a/src/quax/_primitives.py
+++ b/src/quax/_primitives.py
@@ -3,7 +3,7 @@
 __all__ = ()
 
 import weakref
-from typing import Any, cast, no_type_check
+from typing import Any, no_type_check
 
 import jax
 import jax._src.core as core
@@ -58,14 +58,24 @@ def jit_quax(
     key = (id(jaxpr), treedef)
     entry = _jit_quax_cache.get(key)
     if entry is None:
-        fun = quaxify(jexc.jaxpr_as_fun(jaxpr))
-        wref = weakref.ref(jaxpr, _make_cache_finalizer(_jit_quax_cache, key))
-        # Calling _Quaxify.__call__ directly (unbound) bypasses
-        # eqx.Module.__call__'s dir() + BoundMethod overhead.
-        _fun = cast(_Quaxify, fun)
-        qfun = lambda x: _Quaxify.__call__(_fun, *jtu.tree_unflatten(treedef, x))
+        # The cached `jitted` must NOT strongly reference `jaxpr`: doing so would
+        # pin the very object `entry[0]`'s weakref watches, so the finalizer could
+        # never fire and the cache would grow without bound. Instead `qfun`
+        # reaches `jaxpr` through the weakref, resolved only while tracing --
+        # `jax.jit` runs compiled XLA on warm calls and never re-enters this
+        # Python body. During any call `jaxpr` is alive (the caller passes it in),
+        # so the weakref is always live when tracing actually happens.
+        jaxpr_ref = weakref.ref(jaxpr, _make_cache_finalizer(_jit_quax_cache, key))
+
+        def qfun(x: Any, _ref: Any = jaxpr_ref) -> Any:
+            # Constructing `_Quaxify` directly (and calling `__call__` unbound)
+            # bypasses `quaxify()`'s wrapper and eqx.Module.__call__'s dir() +
+            # BoundMethod overhead.
+            fn = _Quaxify(jexc.jaxpr_as_fun(_ref()), True, dynamic=False)
+            return _Quaxify.__call__(fn, *jtu.tree_unflatten(treedef, x))
+
         jitted = jax.jit(qfun)
-        entry = (wref, jitted)
+        entry = (jaxpr_ref, jitted)
         _jit_quax_cache[key] = entry
 
     return entry[1](leaves)  # call without Quax; jax.jit reuses compiled kernel

--- a/tests/unit/test_cache_gc.py
+++ b/tests/unit/test_cache_gc.py
@@ -101,6 +101,42 @@ def test_scan_cache_uses_weakref():
     assert isinstance(entry[0], weakref.ref)
 
 
+def test_jit_cache_does_not_pin_real_jaxpr():
+    """A real quaxified ``@jax.jit`` entry must not pin its own jaxpr.
+
+    Regression for a self-pin: the cached ``jitted`` closure used to reference
+    the jaxpr its ``entry[0]`` weakref watched, so the finalizer could never
+    fire and the cache grew without bound. After the source function and JAX's
+    own caches are dropped, the jaxpr must become collectable and evict the
+    entry. Uses a real ``jit_p`` path (not a fake jaxpr) so the closure's
+    reference graph is actually exercised.
+    """
+    _jit_quax_cache.clear()
+
+    @jax.jit
+    def f(x):
+        return x + 1.0
+
+    # A MyArray Value flows through, so jit_p reaches jit_quax and caches. While
+    # `f` is alive JAX's own pjit cache keeps the jaxpr reachable, so the entry
+    # is present.
+    quax.quaxify(f)(MyArray(jnp.array(0.0)))
+    assert _jit_quax_cache, "Expected _jit_quax_cache to be populated"
+
+    # Drop the source function and JAX's caches. The jaxpr is now reachable only
+    # if the cached entry itself pins it — which is exactly the bug. After the
+    # fix the jaxpr is collected and the finalizer evicts the entry.
+    del f
+    jax.clear_caches()
+    gc.collect()
+    gc.collect()
+
+    assert not _jit_quax_cache, (
+        "jit cache entry survived after its jaxpr became unreachable — the "
+        "cached jitted fn is pinning the jaxpr its weakref watches."
+    )
+
+
 def test_jit_cache_evicts_on_gc():
     """Entry is removed from _jit_quax_cache when the weakreffed jaxpr is collected."""
     jaxpr = _FakeJaxpr()


### PR DESCRIPTION
## Summary

`_jit_quax_cache` was designed to auto-evict entries via a weakref finalizer when a jaxpr is garbage-collected, bounding growth. **It never worked** for this cache: the stored value pinned the very jaxpr its weakref watched.

```python
fun = quaxify(jexc.jaxpr_as_fun(jaxpr))          # .fn = partial(jaxpr_as_fun, jaxpr)
wref = weakref.ref(jaxpr, finalizer)
qfun = lambda x: _Quaxify.__call__(_fun, ...)    # closes over _fun -> holds jaxpr
jitted = jax.jit(qfun)
entry = (wref, jitted)                           # entry[1] transitively holds jaxpr
```

The retention chain: `jitted → qfun → _fun (_Quaxify) → partial(jaxpr_as_fun, jaxpr) → jaxpr` — the same object `entry[0]`'s weakref points at. So the finalizer could never fire, and every distinct trace left a permanent entry.

**Reproduced:** 10 distinct jaxprs stayed pinned (weakrefs alive, entries present) even after `jax.clear_caches()` + `gc.collect()`.

## Fix

Make `qfun` reach the jaxpr through the **weakref**, resolved only while tracing:

```python
jaxpr_ref = weakref.ref(jaxpr, finalizer)
def qfun(x, _ref=jaxpr_ref):
    fn = _Quaxify(jexc.jaxpr_as_fun(_ref()), True, dynamic=False)
    return _Quaxify.__call__(fn, *jtu.tree_unflatten(treedef, x))
jitted = jax.jit(qfun)
entry = (jaxpr_ref, jitted)
```

`jax.jit` runs compiled XLA on warm calls and never re-enters `qfun`'s Python body, so the jaxpr is only dereferenced during tracing — and during any call it's alive because the caller passes it in. The cached `jitted` no longer references the jaxpr, so once JAX drops its own reference the finalizer evicts the entry.

- **Compiled-kernel reuse is unchanged**: warm calls neither recompile nor grow the cache (verified: 51 calls → still 1 entry).
- **Collateral fix for while/scan**: their own cached values never pinned their jaxprs, but a while/scan nested in a quaxified `@jax.jit` had its enclosing jaxpr pinned by the jit cache (which embeds the sub-jaxprs). Fixing the jit cache makes all three collectable.

## Test

Adds `test_jit_cache_does_not_pin_real_jaxpr`, which drives the **real** `jit_p` path (the existing `test_jit_cache_evicts_on_gc` used a fake jaxpr, so it never exercised the closure's reference graph). Fails on the old code, passes after.

Full suite: **1023 passed, 141 skipped**.

## Credit
Root-caused with an adversarial reference-graph investigation (`gc.get_referents` chain + a causal clear-one-cache test isolating jit as the true pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)