### PR TITLE
test: make example-submodule lazy-load test order-independent

### DIFF
--- a/tests/unit/test_examples_imports.py
+++ b/tests/unit/test_examples_imports.py
@@ -1,28 +1,32 @@
 import importlib
 import sys
 
+import quax
 
-EXAMPLE_MODULES = (
-    "lora",
-    "named",
-    "prng",
-    "sparse",
-    "structured_matrices",
-    "unitful",
-    "zero",
+
+# `quax/__init__.py` eagerly aliases these submodules for backwards
+# compatibility (`quax.lora`, `quax.zero`), so they are imported at `quax`
+# import time and are therefore NOT lazily loaded.
+EAGER_MODULES = ("lora", "zero")
+# The genuinely lazy submodules, derived from `quax.examples.__all__` so the
+# list cannot drift as submodules are added or removed.
+LAZY_MODULES = tuple(
+    name for name in quax.examples.__all__ if name not in EAGER_MODULES
 )
 
 
 def clear_examples_modules():
     sys.modules.pop("quax.examples", None)
-    for name in EXAMPLE_MODULES:
+    for name in quax.examples.__all__:
         sys.modules.pop(f"quax.examples.{name}", None)
 
 
 def test_examples_submodules_are_lazy_loaded():
     clear_examples_modules()
     importlib.import_module("quax.examples")
-    assert all(f"quax.examples.{name}" not in sys.modules for name in EXAMPLE_MODULES)
+    # Re-importing `quax.examples` does not re-run `quax/__init__.py`, so the
+    # eager aliases are not re-triggered; only assert the lazy submodules.
+    assert all(f"quax.examples.{name}" not in sys.modules for name in LAZY_MODULES)
 
 
 def test_examples_submodule_loaded_on_attribute_access():


### PR DESCRIPTION
## Problem

`tests/unit/test_examples_imports.py::test_examples_submodules_are_lazy_loaded` was order-dependent and rested on a partly-false premise. It only passed in a full-suite run (where `quax` had already been imported by an earlier test). Run in isolation (`pytest tests/unit/test_examples_imports.py`) it **failed**.

The cause: importing `quax.examples` imports the parent `quax` package, whose `__init__.py` eagerly aliases `lora = examples.lora` and `zero = examples.zero` for backwards compatibility. Those two submodules are therefore loaded **eagerly**, not lazily — so the assertion that *no* example submodule is in `sys.modules` is false whenever `quax/__init__.py` actually runs.

## Fix

- Import `quax` up front so the eager aliasing has already happened, making the test independent of suite ordering.
- Assert only on the genuinely-lazy submodules (`named`, `prng`, `sparse`, `structured_matrices`), derived as `quax.examples.__all__` minus the eager `lora`/`zero`, with a comment explaining why those two are excluded.
- Source the cleared-module list from `quax.examples.__all__` so it can't drift as submodules are added/removed.

`quax/__init__.py` is intentionally left unchanged — making `lora`/`zero` lazy would be a behavior change to the public backward-compat aliases.

## Testing

- `pytest tests/unit/test_examples_imports.py` — now passes in isolation (previously failed).
- Full unit suite: 977 passed, 132 skipped, 37 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)