### PR TITLE
fix: scan support for multi-leaf Values and length-0 scans

### DIFF
--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -128,9 +128,22 @@ else:
         num_xs: int,
         num_ys: int,
     ) -> dict[str, Any]:
-        """Parameters for re-binding `scan_p` with the given group sizes."""
-        del num_xs, num_ys
-        return {**params, "num_consts": num_consts, "num_carry": num_carry}
+        """Parameters for re-binding `scan_p` with the given group sizes.
+
+        `linear` is a per-operand flag tuple (consts + carry + xs). Quaxifying
+        the body generally changes the flat operand count -- a single
+        `ArrayValue` can flatten to several arrays -- so the incoming `linear`
+        no longer matches the new operands and JAX's scan rules raise. Rebuild
+        it sized to the new operand count; the body is retraced from scratch, so
+        no linearity information carries over anyway.
+        """
+        del num_ys
+        return {
+            **params,
+            "num_consts": num_consts,
+            "num_carry": num_carry,
+            "linear": (False,) * (num_consts + num_carry + num_xs),
+        }
 
 
 typeof: Callable[[Any], Any]

--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -131,19 +131,27 @@ else:
         """Parameters for re-binding `scan_p` with the given group sizes.
 
         `linear` is a per-operand flag tuple (consts + carry + xs). Quaxifying
-        the body generally changes the flat operand count -- a single
-        `ArrayValue` can flatten to several arrays -- so the incoming `linear`
-        no longer matches the new operands and JAX's scan rules raise. Rebuild
-        it sized to the new operand count; the body is retraced from scratch, so
-        no linearity information carries over anyway.
+        the body can change the flat operand count -- a single `ArrayValue` may
+        flatten to several arrays -- in which case the incoming `linear` no
+        longer lines up with the new operands and JAX's scan rules raise.
+
+        Only rebuild `linear` when the operand count actually changed. When it
+        matches (the common single-leaf case), keep JAX's original linearity
+        analysis so `lax.scan`'s AD does not lose it to an all-`False` rebuild.
         """
         del num_ys
-        return {
+        new_params = {
             **params,
             "num_consts": num_consts,
             "num_carry": num_carry,
-            "linear": (False,) * (num_consts + num_carry + num_xs),
         }
+        n_operands = num_consts + num_carry + num_xs
+        linear = params.get("linear")
+        if linear is None or len(linear) != n_operands:
+            # Operand count changed: the old per-operand flags no longer align.
+            # The body is retraced from scratch, so no linearity carries over.
+            new_params["linear"] = (False,) * n_operands
+        return new_params
 
 
 typeof: Callable[[Any], Any]

--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -140,11 +140,7 @@ else:
         analysis so `lax.scan`'s AD does not lose it to an all-`False` rebuild.
         """
         del num_ys
-        new_params = {
-            **params,
-            "num_consts": num_consts,
-            "num_carry": num_carry,
-        }
+        new_params = {**params, "num_consts": num_consts, "num_carry": num_carry}
         n_operands = num_consts + num_carry + num_xs
         linear = params.get("linear")
         if linear is None or len(linear) != n_operands:

--- a/src/quax/_primitives.py
+++ b/src/quax/_primitives.py
@@ -211,7 +211,12 @@ def scan_quax(*args: ArrayValue | ArrayLike, jaxpr, **kwargs: Any) -> Any:
     key = (id(jaxpr), c_tree, v_tree, x_tree)
     entry = _scan_quax_cache.get(key)
     if entry is None:
-        trace_in = (*consts_flat, *carry_flat, *[x[0, ...] for x in xs_flat])
+        # Trace the body against one abstract per-step slice of each xs (its
+        # shape without the leading scan axis). Using an abstract slice rather
+        # than a concrete `x[0]` keeps this valid when the scan length is 0,
+        # which `x[0]` would index out of bounds.
+        xs_slices = [jax.ShapeDtypeStruct(x.shape[1:], x.dtype) for x in xs_flat]
+        trace_in = (*consts_flat, *carry_flat, *xs_slices)
         fn = core.jaxpr_as_fun(jaxpr)
 
         @no_type_check  # for beartype

--- a/tests/usage/test_scan.py
+++ b/tests/usage/test_scan.py
@@ -1,9 +1,40 @@
 import jax
+import jax.core
 import jax.numpy as jnp
 import pytest
 
 import quax
 from quax.examples.unitful import kilograms, meters, Unitful
+
+
+class _Pair(quax.ArrayValue):
+    """An `ArrayValue` that flattens to *two* array leaves.
+
+    The shipped example types (`Unitful`, `MyArray`, ...) all flatten to a
+    single array leaf, so they never exercised the scan path where quaxifying
+    the body changes the flat operand count. `_Pair` does, with field-wise
+    arithmetic so a scan body built from `+`/`*` has predictable per-field
+    semantics.
+    """
+
+    a: jax.Array
+    b: jax.Array
+
+    def aval(self) -> jax.core.ShapedArray:
+        return jax.core.ShapedArray(self.a.shape, self.a.dtype)
+
+    def materialise(self) -> jax.Array:
+        return self.a
+
+
+@quax.register(jax.lax.add_p)
+def _(x: _Pair, y: _Pair) -> _Pair:
+    return _Pair(x.a + y.a, x.b + y.b)
+
+
+@quax.register(jax.lax.mul_p)
+def _(x: _Pair, y: _Pair) -> _Pair:
+    return _Pair(x.a * y.a, x.b * y.b)
 
 
 def _outer_fn(const, init, xs):
@@ -63,6 +94,53 @@ def test_scan_vmap():
 
     assert final_carry.units == {meters: 1}
     assert ys1.units == ys2.units == {meters: 2}
+
+
+def test_scan_multileaf_value():
+    """A Value that flattens to multiple array leaves as const/carry/xs.
+
+    Regression: the quaxified body has more flat operands than the original, so
+    the (pre-0.11) re-bind forwarded a stale `linear` tuple sized to the old
+    operand count, and JAX's scan rules raised `safe_zip(...)`.
+    """
+    const = _Pair(jnp.asarray(1.0), jnp.asarray(10.0))
+    init = _Pair(jnp.asarray(0.0), jnp.asarray(0.0))
+    xs = _Pair(jnp.arange(1.0, 4.0), jnp.arange(1.0, 4.0) * 10.0)
+
+    def outer(const, init, xs):
+        return jax.lax.scan(lambda c, x: (c + x + const, c), init, xs)
+
+    final_carry, ys = quax.quaxify(jax.jit(outer))(const, init, xs)
+
+    # Reference: two independent single-field scans.
+    def ref(c0, cst, xarr):
+        return jax.lax.scan(lambda c, x: (c + x + cst, c), c0, xarr)
+
+    fa, ya = ref(jnp.asarray(0.0), jnp.asarray(1.0), jnp.arange(1.0, 4.0))
+    fb, yb = ref(jnp.asarray(0.0), jnp.asarray(10.0), jnp.arange(1.0, 4.0) * 10.0)
+
+    assert isinstance(final_carry, _Pair) and isinstance(ys, _Pair)
+    assert jnp.allclose(final_carry.a, fa) and jnp.allclose(final_carry.b, fb)
+    assert jnp.allclose(ys.a, ya) and jnp.allclose(ys.b, yb)
+
+
+def test_scan_length_zero():
+    """A scan over a length-0 leading axis. Regression: the body was traced by
+    concretely indexing `xs[0]`, which is out of bounds when the length is 0.
+    Plain `lax.scan` runs zero steps and returns the initial carry + empty ys.
+    """
+    init = _Pair(jnp.asarray(1.0), jnp.asarray(2.0))
+    xs = _Pair(jnp.zeros((0,)), jnp.zeros((0,)))
+
+    def outer(init, xs):
+        return jax.lax.scan(lambda c, x: (c + x, c), init, xs)
+
+    final_carry, ys = quax.quaxify(jax.jit(outer))(init, xs)
+
+    assert isinstance(final_carry, _Pair) and isinstance(ys, _Pair)
+    # Zero steps -> carry unchanged, ys empty.
+    assert jnp.allclose(final_carry.a, 1.0) and jnp.allclose(final_carry.b, 2.0)
+    assert ys.a.shape == (0,) and ys.b.shape == (0,)
 
 
 def test_scan_grad():


### PR DESCRIPTION
## Summary

Two independent `scan` bugs, both masked by the fact that every shipped example type (`Unitful`, `MyArray`, …) flattens to a **single** array leaf — so neither was exercised by the existing tests. Found via a discovery-pass audit.

### 1. Multi-leaf Values crash `scan` (pre-0.11 path) — High
Quaxifying the scan body can change the flat operand count: a single `ArrayValue` may flatten to several arrays. But the pre-0.11 `scan_bind_params` forwarded the original `linear` tuple unchanged, whose length is the per-operand count. With more operands than `linear` entries, JAX's scan rules raise:

```
ValueError: safe_zip() argument 2 is longer than argument 1
```

This breaks `scan` for essentially **any real multi-field `ArrayValue`** on JAX < 0.11. Fix: rebuild `linear` sized to the new operand count (the body is retraced from scratch, so no linearity information carries over). The 0.11+ path already rebuilds its `ft_in`/`ft_out` descriptors from the flat counts and was unaffected.

### 2. Length-0 scans crash on all JAX versions — Medium
The body was traced by concretely indexing `xs[0]` to obtain a per-step slice, which is out of bounds when the scanned axis has length 0:

```
IndexError: index is out of bounds for axis 0 with size 0
```

Plain `lax.scan` handles length 0 fine (zero steps → initial carry + empty ys). Fix: trace against an abstract per-step slice `jax.ShapeDtypeStruct(x.shape[1:], x.dtype)` instead of `xs[0]`.

## Tests

Adds a two-array-leaf `_Pair` `ArrayValue` (with field-wise `add`/`mul`) and two regression tests: `test_scan_multileaf_value` and `test_scan_length_zero`. Both fail on the old code with the exact errors above and pass after. Full suite: **1029 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)