### PR TITLE
fix: prng.normal complex dtypes & prng.uniform array-valued bounds

### DIFF
--- a/src/quax/examples/prng/_core.py
+++ b/src/quax/examples/prng/_core.py
@@ -94,8 +94,11 @@ def uniform(
     dtype = jax.dtypes.canonicalize_dtype(dtype)
     minval = lax.convert_element_type(minval, dtype)
     maxval = lax.convert_element_type(maxval, dtype)
-    minval = jnp.broadcast_to(minval, (1,) * (len(shape) - minval.ndim))
-    maxval = jnp.broadcast_to(maxval, (1,) * (len(shape) - maxval.ndim))
+    # Broadcast the (possibly array-valued) bounds up to the output rank, keeping
+    # their own trailing dims -- as `jax.random.uniform` does. A plain
+    # `broadcast_to` to an all-ones shape mishandles any non-scalar bound.
+    minval = lax.broadcast_to_rank(minval, len(shape))
+    maxval = lax.broadcast_to_rank(maxval, len(shape))
 
     finfo = jnp.finfo(dtype)
     nbits = finfo.bits
@@ -132,8 +135,8 @@ def normal(
     PRNGs, e.g. `prng.ThreeFry(...)`.
     """
 
-    if not jnp.issubdtype(dtype, jnp.floating):
-        raise ValueError("Must use floating dtype")
+    if not jnp.issubdtype(dtype, jnp.inexact):
+        raise ValueError("Must use floating or complex dtype")
     dtype = jax.dtypes.canonicalize_dtype(dtype)
     if jnp.issubdtype(dtype, jnp.complexfloating):
         sqrt2 = np.array(np.sqrt(2), dtype)

--- a/src/quax/examples/prng/_core.py
+++ b/src/quax/examples/prng/_core.py
@@ -11,7 +11,7 @@ import jax.lax as lax
 import jax.numpy as jnp
 import jax.tree_util as jtu
 import numpy as np
-from jaxtyping import Array, ArrayLike, Float, Integer, UInt, UInt32
+from jaxtyping import Array, ArrayLike, Float, Inexact, Integer, UInt, UInt32
 
 import quax
 from quax._compat import JAX_GE_0_10_2
@@ -82,7 +82,7 @@ def uniform(
     dtype: DTypeLikeFloat = jnp.float_,
     minval: RealArray = 0.0,
     maxval: RealArray = 1.0,
-) -> Float[Array, ""]:
+) -> Float[Array, "..."]:
     """Samples a random number uniformly distributed over `[minval, maxval)`.
 
     Arguments as `jax.random.uniform`, except that the first argument must be one of our
@@ -128,7 +128,7 @@ def uniform(
 
 def normal(
     key: PRNG, shape: tuple[int, ...] = (), dtype: DTypeLikeInexact = jnp.float_
-) -> Float[Array, ""]:
+) -> Inexact[Array, "..."]:
     """Samples from a normal distribution.
 
     Arguments as `jax.random.normal`, except that the first argument must be one of our

--- a/tests/usage/test_prng.py
+++ b/tests/usage/test_prng.py
@@ -19,6 +19,46 @@ def test_normal():
     prng.normal(key)
 
 
+def test_normal_complex():
+    """`normal` supports complex dtypes (as `jax.random.normal` does).
+
+    Regression: the dtype guard tested `jnp.floating`, which excludes complex,
+    so any complex dtype raised before reaching the (fully written) complex
+    branch -- making that branch dead code.
+    """
+    key = prng.ThreeFry(0)
+    out = prng.normal(key, shape=(5,), dtype=jnp.complex64)
+    assert out.dtype == jnp.complex64
+    assert out.shape == (5,)
+
+
+def test_normal_rejects_integer():
+    key = prng.ThreeFry(0)
+    with pytest.raises(ValueError):
+        prng.normal(key, shape=(2,), dtype=jnp.int32)
+
+
+def test_uniform_array_bounds():
+    """`uniform` accepts array-valued `minval`/`maxval` (as `jax.random.uniform`).
+
+    Regression: the bounds were broadcast to an all-ones shape of the wrong
+    rank, so any non-scalar bound raised instead of giving a per-element range.
+    """
+    key = prng.ThreeFry(0)
+    minval = jnp.array([0.0, 10.0, 20.0])
+    maxval = jnp.array([1.0, 11.0, 21.0])
+
+    # Per-element bounds.
+    out = prng.uniform(key, shape=(3,), minval=minval, maxval=maxval)
+    assert out.shape == (3,)
+    assert bool((out >= minval).all() and (out < maxval).all())
+
+    # Bounds broadcast against a higher-rank output shape.
+    out2 = prng.uniform(key, shape=(4, 3), minval=minval, maxval=maxval)
+    assert out2.shape == (4, 3)
+    assert bool((out2 >= minval).all() and (out2 < maxval).all())
+
+
 def test_cannot_add():
     key = prng.ThreeFry(0)
     with pytest.raises(TypeError):


### PR DESCRIPTION
## Summary

Two deviations from the documented "Arguments as `jax.random.{normal,uniform}`" contract in the `prng` example.

### `normal` rejected complex dtypes (dead code)
The dtype guard tested `jnp.floating`, which **excludes complex**, so a complex dtype raised at the guard before ever reaching the complex-sampling branch just below it — making that branch **dead code**, despite the parameter being annotated `DTypeLikeInexact`.

```python
-    if not jnp.issubdtype(dtype, jnp.floating):
-        raise ValueError("Must use floating dtype")
+    if not jnp.issubdtype(dtype, jnp.inexact):   # float OR complex, as jax does
+        raise ValueError("Must use floating or complex dtype")
```

`uniform` stays float-only (as `jax.random.uniform` is).

### `uniform` crashed on array-valued `minval`/`maxval`
`jax.random.uniform` accepts array bounds, but the broadcast built an all-ones target of the wrong rank:

```python
-    minval = jnp.broadcast_to(minval, (1,) * (len(shape) - minval.ndim))   # wrong rank
+    minval = lax.broadcast_to_rank(minval, len(shape))                     # as jax's _uniform
```

Only scalar bounds worked before; `minval=[0,10,20]` raised.

## Tests

Adds regression tests to `tests/usage/test_prng.py`: complex `normal`, integer-`normal` still rejected, and per-element / broadcast `uniform` bounds. The two new bug cases fail on the old code. Full suite: **1030 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)