### PR TITLE
bench: add control-flow and cached-jit-path benchmarks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -34,10 +34,11 @@ jobs:
       - name: Install
         run: uv sync --no-default-groups --group bench --locked
 
-      # Run the construction/allocation micro-benchmarks and the eager-dispatch
-      # operation benchmarks (add/mul/matmul on quax Values) under CodSpeed's
-      # deterministic instrumentation mode — these capture the quax construction +
-      # dispatch overhead the perf work targets. The XLA-heavy `test_numpy.py`
+      # Run the construction/allocation micro-benchmarks, the eager-dispatch
+      # operation benchmarks (add/mul/matmul on quax Values), and the control-flow
+      # handler benchmarks (while/cond/scan) under CodSpeed's deterministic
+      # instrumentation mode — these capture the quax construction + dispatch +
+      # control-flow overhead the perf work targets. The XLA-heavy `test_numpy.py`
       # jit-compile/execute benchmarks are impractical under valgrind, so they stay
       # local-only (`pytest tests/benchmark --benchmark-only`).
       #
@@ -53,5 +54,6 @@ jobs:
             uv run --frozen pytest
             tests/benchmark/test_construction.py
             tests/benchmark/test_dispatch.py
+            tests/benchmark/test_control_flow.py
             --codspeed -o addopts= -p no:env
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/tests/benchmark/test_control_flow.py
+++ b/tests/benchmark/test_control_flow.py
@@ -1,0 +1,68 @@
+"""Benchmarks for quax's control-flow primitive handlers.
+
+``scan_quax``, ``while_quax``, and ``cond_quax`` each build (and cache) a
+quaxified sub-jaxpr for the loop/branch body and re-bind the primitive with it.
+They are a core part of quax -- distinct from the elementwise dispatch in
+``test_dispatch`` -- and had no other benchmark coverage. A regression in that
+machinery (the jaxpr caches, the ``_compat`` scan-param handling, or the
+carry/branch pytree bookkeeping) shows up here.
+
+Each body is wrapped in ``jax.jit`` and warmed once before timing, so the timed
+call is the steady-state path a real program hits: the quaxified body jaxpr is
+built and compiled during warm-up (outside the measurement), and each timed call
+re-enters the quax trace, hits the cached ``jit_quax`` kernel, and runs the
+compiled loop/branch. (Eager ``quaxify`` without ``jax.jit`` would instead rebuild
+and recompile the body on every call -- and ``scan_p`` never even reaches
+``scan_quax`` outside ``jit``.) Small operands keep XLA a sliver.
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import quax
+
+from ..unit.myarray import MyArray
+
+
+_scan_init = MyArray(jnp.array(1.0))
+_scan_xs = MyArray(jnp.arange(1.0, 4.0))
+_while_init = MyArray(jnp.array(0.0))
+_cond_x = MyArray(jnp.arange(8.0) + 1)
+
+
+def _bench(benchmark, fn, *args):
+    """Warm the jit + dispatch caches, then benchmark the steady-state call."""
+    qfn = quax.quaxify(jax.jit(fn))
+    qfn(*args)  # compile the body and fill the quax caches
+    benchmark(lambda: qfn(*args))
+
+
+@pytest.mark.benchmark(group="control_flow")
+def test_scan(benchmark):
+    """`quaxify(jit(...))` over a `lax.scan` — exercises `scan_quax` + its cache."""
+
+    def f(init, xs):
+        return jax.lax.scan(lambda c, x: (c + x, c * x), init, xs)
+
+    _bench(benchmark, f, _scan_init, _scan_xs)
+
+
+@pytest.mark.benchmark(group="control_flow")
+def test_while(benchmark):
+    """`quaxify(jit(...))` over a `lax.while_loop` — exercises `while_quax`."""
+
+    def f(x):
+        return jax.lax.while_loop(lambda c: c < 5.0, lambda c: c + 1.0, x)
+
+    _bench(benchmark, f, _while_init)
+
+
+@pytest.mark.benchmark(group="control_flow")
+def test_cond(benchmark):
+    """`quaxify(jit(...))` over a `lax.switch` — exercises `cond_quax`."""
+
+    def f(index, x):
+        return jax.lax.switch(index, [lambda a: a + 1.0, lambda a: a * 2.0], x)
+
+    _bench(benchmark, f, 0, _cond_x)

--- a/tests/benchmark/test_dispatch.py
+++ b/tests/benchmark/test_dispatch.py
@@ -38,6 +38,19 @@ _rhs = jax.random.normal(_key, (16, 8))
 _dot_dn = (((1,), (0,)), ((), ()))
 
 
+# An inner `@jax.jit` that quax does *not* inline, so its `pjit` takes the cached
+# `jit_quax` path (`_jit_quax_cache` — a jax.jit-wrapped quaxify callable whose
+# compiled kernel is reused), distinct from the inlined-`pjit` path the other
+# dispatch benchmarks hit.
+@jax.jit
+def _inner_jit(a):
+    return a * 2.0 + 1.0
+
+
+def _calls_inner_jit(a):
+    return _inner_jit(a)
+
+
 def _bench(benchmark, fn, *args):
     """Warm the dispatch cache, then benchmark eager ``quaxify(fn)(*args)``."""
     qfn = quax.quaxify(fn)
@@ -76,3 +89,10 @@ def test_matmul_lora(benchmark):
     """`quaxify(dot_general)(LoraArray, array)` — LoRA matmul (many primitives,
     inlined pjits)."""
     _bench(benchmark, lax.dot_general, _lora, _rhs, _dot_dn)
+
+
+@pytest.mark.benchmark(group="dispatch")
+def test_jit_cache_hit(benchmark):
+    """`quaxify` over a function calling an inner `@jax.jit` — the cached
+    (non-inlined) `jit_quax` path, hitting `_jit_quax_cache`."""
+    _bench(benchmark, _calls_inner_jit, _xm)


### PR DESCRIPTION
## Summary

The benchmark suite covered construction and eager elementwise dispatch, but two **core** hot paths — both recently the site of bug fixes — had **no** coverage. This adds focused, deterministic benchmarks for them (nothing speculative).

### Control flow — `test_control_flow.py` (new)
`scan_quax` / `while_quax` / `cond_quax` each build and cache a quaxified body jaxpr and re-bind the primitive — a major part of what quax does, with zero prior benchmark coverage. Benchmarks scan / while / cond via `quaxify(jax.jit(...))`, **warmed once** so the timed call is the steady-state path (cached body kernel + quax dispatch), not an eager rebuild.

> Design note: eager `quaxify(fn)` recompiles the loop/branch on **every** call (measured 14–25 ms, high variance — valgrind-hostile), and `scan_p` never even reaches `scan_quax` outside `jit`. The `jax.jit`-wrapped warm form is stable (~40–55 µs) and matches how the recommended usage actually runs.

### Cached `jit_quax` path — `test_dispatch.py::test_jit_cache_hit`
Every existing dispatch benchmark hits the *inlined*-pjit path. This drives a non-inlined inner `@jax.jit`, exercising `_jit_quax_cache` — the cache whose compiled-kernel reuse `jax.jit(quaxify(...))` depends on (and where the recent weakref-pin memory leak, #187, lived).

## Why these (and not more)
Kept deliberately minimal and well-scoped:
- Small operands → quax's Python trace/dispatch overhead dominates (XLA a sliver), so numbers are meaningful and deterministic under CodSpeed's instruction-counting instrumentation.
- Each covers a **distinct** path not measured elsewhere (control-flow handlers; the cached vs inlined pjit path).
- Verified locally: all 14 CodSpeed-run benchmarks pass under `--codspeed`; the new control-flow ones are warm/stable (medians 39/45/53 µs, low IQR).

`test_control_flow.py` is added to the CodSpeed CI run alongside construction and dispatch. The XLA-heavy `test_numpy.py` jit-compile/execute benchmarks remain local-only, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)