### PR TITLE
fix: named elementwise ops validate axis names pairwise (like dot_general)

### DIFF
--- a/src/quax/examples/named/_core.py
+++ b/src/quax/examples/named/_core.py
@@ -107,24 +107,28 @@ def _broadcast_axes(axes1, axes2):
 def _register_elementwise_binop(
     op: Callable[[Any, Any], Any], prim: jex.core.Primitive
 ):
-    quax_op = quax.quaxify(op)
+    # Re-bind `prim` (rather than call the high-level `op`) so its parameters are
+    # forwarded unchanged -- e.g. the `out_dtype` newer JAX threads through
+    # `mul_p`, which the handlers must accept or dispatch fails with an
+    # "unexpected keyword argument" error.
+    bind = quax.quaxify(prim.bind)
 
     @quax.register(prim)
-    def _(x: NamedArray, y: NamedArray) -> NamedArray:
+    def _(x: NamedArray, y: NamedArray, **params: Any) -> NamedArray:
         axes = _broadcast_axes(x.axes, y.axes)
-        return NamedArray(quax_op(x.array, y.array), axes)
+        return NamedArray(bind(x.array, y.array, **params), axes)
 
     @quax.register(prim)
-    def _(x: ArrayLike | quax.ArrayValue, y: NamedArray) -> NamedArray:
+    def _(x: ArrayLike | quax.ArrayValue, y: NamedArray, **params: Any) -> NamedArray:
         if quax.quaxify(jnp.shape)(x) == ():
-            return NamedArray(quax_op(x, y.array), y.axes)
+            return NamedArray(bind(x, y.array, **params), y.axes)
         else:
             raise ValueError(f"Cannot apply {op} to non-scalar array and named array.")
 
     @quax.register(prim)
-    def _(x: NamedArray, y: ArrayLike | quax.ArrayValue) -> NamedArray:
+    def _(x: NamedArray, y: ArrayLike | quax.ArrayValue, **params: Any) -> NamedArray:
         if quax.quaxify(jnp.shape)(y) == ():
-            return NamedArray(quax_op(x.array, y), x.axes)
+            return NamedArray(bind(x.array, y, **params), x.axes)
         else:
             raise ValueError(f"Cannot apply {op} to non-scalar array and named array.")
 

--- a/src/quax/examples/named/_core.py
+++ b/src/quax/examples/named/_core.py
@@ -87,16 +87,21 @@ NamedArray.__init__.__doc__ = """**Arguments:**
 
 
 def _broadcast_axes(axes1, axes2):
+    # By the time an elementwise `*_p` fires, JAX has already broadcast the
+    # operands to the same rank, so two `NamedArray`s reaching here have
+    # equal-length axis tuples (differing ranks fail earlier: `NamedArray` has
+    # no `broadcast_in_dim` rule). The names must then match by position -- as
+    # the `dot_general` rule validates its pairing, names check that operands
+    # share matching semantics rather than reordering to align (see the module
+    # README). A set-based check instead accepts reordered names (e.g. (A, B)
+    # against (B, A)), which are then computed positionally and mislabelled.
     if len(axes1) == 0:
         return axes2
-    elif len(axes2) == 0:
+    if len(axes2) == 0:
         return axes1
-    elif set(axes1).issubset(set(axes2)):
-        return axes2
-    elif set(axes2).issubset(set(axes1)):
-        return axes1
-    else:
-        raise ValueError(f"Cannot broadcast {axes1} against {axes2}")
+    if axes1 != axes2:
+        raise ValueError(f"Cannot broadcast named axes {axes1} against {axes2}.")
+    return axes1
 
 
 def _register_elementwise_binop(

--- a/tests/usage/test_named.py
+++ b/tests/usage/test_named.py
@@ -41,6 +41,26 @@ def test_add(getkey):
     assert out2 == true_out
 
 
+def test_add_axis_mismatch(getkey):
+    # Elementwise ops combine the underlying arrays positionally, so adding
+    # (A, B) to (B, A) is a name mismatch. The old set-based broadcast check
+    # accepted it and silently computed the positional sum with mislabelled
+    # axes; now it is rejected, matching how `dot_general` validates its pairing.
+    A = named.Axis(3)
+    B = named.Axis(3)
+    x = named.NamedArray(jr.normal(getkey(), (3, 3)), (A, B))
+    y_reversed = named.NamedArray(jr.normal(getkey(), (3, 3)), (B, A))
+    y_aligned = named.NamedArray(jr.normal(getkey(), (3, 3)), (A, B))
+
+    for op in (lambda a, b: a + b, lambda a, b: a * b, lambda a, b: a - b):
+        # Reordered axes are rejected...
+        with pytest.raises(ValueError, match="Cannot broadcast named axes"):
+            quax.quaxify(op)(x, y_reversed)
+        # ...and aligned axes (A with A, B with B) combine fine.
+        out = quax.quaxify(op)(x, y_aligned)
+        assert out.axes == (A, B)
+
+
 def test_matmul(getkey):
     Foo = named.Axis(3)
     Bar = named.Axis(3)


### PR DESCRIPTION
## Summary

Follow-up to #192 (which fixed the same class of bug for `dot_general`). The `named` example's elementwise ops had the **same silent-mislabel hole**. The README makes the intended semantics explicit:

> "arrays with named dimensions … to **check that we only perform matmuls down axes with matching semantics**."

So names **validate** matching semantics; they do not reorder/transpose to align (that would be a different, xarray-style feature). #192 made `dot_general` validate pairwise; the binops still did not.

## The bug

`_broadcast_axes` used a set/subset check:

```python
elif set(axes1).issubset(set(axes2)): return axes2   # (A,B) vs (B,A): {A,B}⊆{B,A} → True
...
return NamedArray(quax_op(x.array, y.array), axes)   # but x+y is positional
```

So `NamedArray(a, (A, B)) + NamedArray(b, (B, A))` passed, computed `a + b` **positionally**, and labelled the result `(B, A)` — a silent wrong labelling. Same for `mul`/`sub`.

## The fix

By the time an elementwise `*_p` fires, JAX has already broadcast the operands to the same rank, so the two axis tuples reaching `_broadcast_axes` are **equal-length**. Require them to be equal (same names, same order); reject otherwise. (Differing ranks never reach here — `NamedArray` has no `broadcast_in_dim` rule, so a lower-rank operand fails at the broadcast step regardless; the old subset branch was effectively dead for the `NamedArray + NamedArray` path.)

## Tests

`test_add_axis_mismatch` checks all three ops (`add`/`mul`/`sub`): reordered `(A,B)` vs `(B,A)` is rejected with "Cannot broadcast named axes", and aligned axes combine fine. Full suite: **1032 passed** (jaxtyping/beartype on).

Closes audit finding #7 — the last known correctness gap in the `named` example, now consistent with `dot_general`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)