### PR TITLE
docs(named): fix typo and document validate-not-align axis semantics

### DIFF
--- a/src/quax/examples/named/README.md
+++ b/src/quax/examples/named/README.md
@@ -1,6 +1,6 @@
 # Named arrays
 
-These are arrays with named dimensions. We can then use these to specify which dimensions we'd like to reduce down, or e.g. to check that we only perform matmuls down axes with matchign semantics.
+These are arrays with named dimensions. We can then use these to specify which dimensions we'd like to reduce down, or e.g. to check that we only perform matmuls down axes with matching semantics.
 
 ## Example
 
@@ -36,3 +36,24 @@ named.trace       # Trace down two named axes.
 ```
 
 The usual JAX addition, subtraction, multiplication, and contraction (matrix-vector multiplication; matrix-matrix multiplication `jnp.tensordot` etc.) are also supported.
+
+## Semantics
+
+Names **validate**; they do not **align**. Operations run positionally, exactly as
+the usual JAX operations do, and the names are checked to line up with that
+positional pairing (and used to label the output):
+
+- For an elementwise op, the operands must have the *same axes in the same
+  order* — `(A, B) + (B, A)` is rejected, not silently transposed and added.
+- For a contraction, each contracted (and batched) axis must share a name with
+  the axis it is *positionally* paired against — `dot_general` contracts
+  `lhs_contract[k]` with `rhs_contract[k]`, so those two axes must match.
+
+This deliberately differs from a fully name-driven system (e.g. `xarray`), which
+would *reorder* operands to align shared names. Here a mismatch is an error,
+surfacing a likely bug rather than quietly reinterpreting the operation.
+
+Axes are matched by **identity**: two axes are "the same name" only if they are
+the same `Axis` object (so re-using an `Axis` instance is how you express that
+two arrays share a dimension). Two separately constructed `Axis(3)`s are
+distinct names.


### PR DESCRIPTION
## Summary

Small docs polish for the `named` example, closing out the last loose ends from the discovery sweep.

- **Typo:** "matchi**gn** semantics" → "matching semantics".
- **New "Semantics" section** documenting the design that #192 (dot_general) and #194 (elementwise ops) now enforce: **names validate, they do not align.** Operations run positionally (as usual JAX ops do), and names are checked to line up with that positional pairing:
  - elementwise ops require the same axes in the same order (`(A, B) + (B, A)` is rejected, not silently transposed);
  - contraction requires each contracted/batched axis to share a name with the axis it is *positionally* paired against.

  It also notes this deliberately differs from a fully name-driven system (xarray, which reorders to align), and that axes match by **`Axis` identity** (re-use an `Axis` instance to express a shared dimension).

Docs-only; example READMEs are not doctested, so no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)