### PR TITLE
🐛 fix(module): restore dataclass_transform for Value subclasses

### DIFF
--- a/src/quax/_module.py
+++ b/src/quax/_module.py
@@ -42,12 +42,21 @@ __all__ = ()
 import dataclasses
 import warnings
 import weakref
-from typing import Any, NamedTuple
+from typing import Any, dataclass_transform, NamedTuple, TYPE_CHECKING
 
 import equinox as eqx
 
 
-_EqxModuleMeta = type(eqx.Module)
+if TYPE_CHECKING:
+    # Static checkers cannot resolve `type(eqx.Module)` to a concrete class, which
+    # severs the metaclass chain and stops the `dataclass_transform` below from
+    # reaching `Value` subclasses (their `__init__` would look untyped). Import the
+    # metaclass by name for type-checking only; the runtime path keeps
+    # `type(eqx.Module)` so a future equinox rename degrades gracefully at run time
+    # instead of breaking import.
+    from equinox._module._module import _ModuleMeta as _EqxModuleMeta
+else:
+    _EqxModuleMeta = type(eqx.Module)
 
 # Internals the fast path depends on. Kept behind a guarded import so that a change
 # in `equinox` degrades to the slow-but-correct path rather than breaking at import.
@@ -107,6 +116,13 @@ class _FastSpec(NamedTuple):
 _fast_specs: "weakref.WeakKeyDictionary[type, _FastSpec]" = weakref.WeakKeyDictionary()
 
 
+# Re-declare equinox's `dataclass_transform` on this metaclass. PEP 681 does not
+# propagate the marker to a metaclass subclass, so without this static type checkers
+# stop treating `quax.Value` (and every user subclass) as a dataclass: constructor
+# calls become "untyped" and `dataclasses.replace(..., field=...)` is rejected. At
+# runtime the transform is inherited from equinox regardless; this only restores the
+# static view. Field specifiers mirror `equinox._module._module._ModuleMeta`.
+@dataclass_transform(field_specifiers=(dataclasses.field, eqx.field))
 class _FastModuleMeta(_EqxModuleMeta):
     """Metaclass that skips `equinox.Module`'s per-instance validation where safe.
 

--- a/tests/unit/test_fast_module.py
+++ b/tests/unit/test_fast_module.py
@@ -23,6 +23,18 @@ def test_value_uses_fast_metaclass():
     assert isinstance(quax.ArrayValue, _FastModuleMeta)
 
 
+def test_fast_metaclass_declares_dataclass_transform():
+    """`dataclass_transform` must be applied *directly* to `_FastModuleMeta`.
+
+    PEP 681 does not propagate the marker to a metaclass subclass, so a static type
+    checker only treats `quax.Value` subclasses as dataclasses (typed `__init__`,
+    field-aware `dataclasses.replace`) when the decorator sits on `_FastModuleMeta`
+    itself. Inheriting it from equinox's `_ModuleMeta` is not enough -- hence the
+    check on the class's own ``__dict__`` rather than ``hasattr``.
+    """
+    assert "__dataclass_transform__" in _FastModuleMeta.__dict__
+
+
 def test_fast_path_available():
     """CI canary: the fast construction path must stay live on supported equinox.
 


### PR DESCRIPTION
## Problem

`_FastModuleMeta` (introduced in v0.4.0 for fast `Module` construction) silently broke **static typing** for every `quax.Value` / `quax.ArrayValue` subclass. Type checkers stopped treating them as dataclasses:

- constructor calls report `Call to untyped function "..." in typed context [no-untyped-call]`
- `dataclasses.replace(value, field=...)` reports `Unexpected keyword argument "field" for "replace" [call-arg]`

Runtime is entirely unaffected (the `__dataclass_transform__` marker is inherited from equinox at run time), which is why it went unnoticed — quax has no type-checking CI job. It surfaced downstream in [GalacticDynamics/quaxed#197](https://github.com/GalacticDynamics/quaxed/pull/197), whose `MyArray(quax.ArrayValue)` test helper produced ~40 mypy errors under quax 0.4.0 while all 1081 runtime tests passed.

## Root cause (two independent issues)

1. **PEP 681 does not inherit `@dataclass_transform` across a metaclass subclass.** `_FastModuleMeta(_EqxModuleMeta)` re-declared none, so checkers didn't see it as dataclass-transforming — even though its base is.
2. **`_EqxModuleMeta = type(eqx.Module)` is opaque to static checkers** — mypy reports `Variable is not valid as a type`, which severs the metaclass base entirely, so even a re-declared transform wouldn't apply.

I isolated each with minimal `reveal_type` repros before fixing.

## Fix

- Apply `@dataclass_transform(field_specifiers=(dataclasses.field, eqx.field))` directly to `_FastModuleMeta`, mirroring equinox's `_ModuleMeta`.
- Import the concrete metaclass by name **under `TYPE_CHECKING`** so checkers get a resolvable base; the runtime path keeps `type(eqx.Module)` for graceful degradation on an equinox rename.

## Verification

- `reveal_type(Foo.__init__)` for `Foo(quax.ArrayValue)` → `def (self: Foo, array: ...)` (was `def (self: object)`).
- quaxed's `MyArray` mypy errors: ~40 → **0**.
- `tests/unit/test_fast_module.py`: 16 passed (incl. new regression test); runtime construction + `replace` confirmed working.
- Repo pre-commit (ruff, ruff-format, **pyright**) passes.

Added a regression test asserting the marker is on `_FastModuleMeta`'s **own** `__dict__` — inheriting it from equinox is not enough for static checkers, so a plain `hasattr` check would not have caught this.

> Note: quax has no mypy/pyright CI job, which is why this shipped. Worth considering a type-check job (or a `tests/static` `assert_type` suite) so downstream-visible typing regressions turn CI red here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)