### PR TITLE
🏷️ types(module): return the concrete type from `_FastModuleMeta.__call__`

### DIFF
--- a/src/quax/_module.py
+++ b/src/quax/_module.py
@@ -42,9 +42,16 @@ __all__ = ()
 import dataclasses
 import warnings
 import weakref
-from typing import Any, dataclass_transform, NamedTuple, TYPE_CHECKING
+from typing import Any, cast, dataclass_transform, NamedTuple, TYPE_CHECKING, TypeVar
 
 import equinox as eqx
+
+
+# The class being constructed (see `_FastModuleMeta.__call__`), so construction
+# returns the concrete type. Left unbounded: a bound (even `eqx.Module`) makes
+# `type[_T]` too narrow to annotate a metaclass `cls` parameter ("must be a
+# supertype of its class `_FastModuleMeta`").
+_T = TypeVar("_T")
 
 
 if TYPE_CHECKING:
@@ -162,17 +169,27 @@ class _FastModuleMeta(_EqxModuleMeta):
             _fast_specs[cls] = _FastSpec(field_names, converters, checks)
         return cls
 
-    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+    def __call__(cls: type[_T], *args: Any, **kwargs: Any) -> _T:
+        # `type[_T] -> _T` so a construction `MyValue(...)` type-checks as
+        # `MyValue`, not `Any`: pyright uses the metaclass `__call__` return type
+        # for the constructor expression, so a plain `-> Any` here would erase the
+        # `dataclass_transform`-synthesised signature for every `Value` subclass.
+        # `self` below stays `Any` (an instance of a dynamically-determined class),
+        # which is unrelated to this outward-facing return type.
+        #
         # A class the fast path could not analyse is absent from `_fast_specs`;
         # abstract instantiation is still deferred to equinox's own __call__ (which
         # raises the right errors and runs the full validation).
         spec = _fast_specs.get(cls)
         if spec is None or is_abstract_module(cls):
-            return super().__call__(*args, **kwargs)
+            # equinox's `__call__` is typed `Any | None`; it returns an instance
+            # of `cls` for the non-abstract, non-singleton path.
+            return cast(_T, super().__call__(*args, **kwargs))
 
-        # `self` is a freshly-allocated instance of a dynamically-determined class;
-        # `Any` is the honest type and avoids metaclass-`Self` typing friction on the
-        # `_currently_initialising` / `object.__setattr__` calls below.
+        # `self` is typed `Any` (a freshly-allocated instance of a
+        # dynamically-determined class), which avoids metaclass-`Self` typing
+        # friction on the `_currently_initialising` / `object.__setattr__` calls
+        # below without affecting the `-> _T` return type documented above.
         #
         # Forward the constructor arguments to `__new__`, matching `type.__call__`
         # (and equinox's slow path): a `Value` may override `__new__` to consume
@@ -189,11 +206,13 @@ class _FastModuleMeta(_EqxModuleMeta):
         # equinox's own __setattr__ warnings still fire for those assignments). A
         # dataclass-generated __init__ uses object.__setattr__ and does not need
         # this, but registering unconditionally is cheap and uniform.
-        _currently_initialising.add(self)
+        # (`isinstance` above narrows `self` to `_T`; it is an `eqx.Module` here, but
+        # `_T` is unbounded, so the guard-set calls need a suppression.)
+        _currently_initialising.add(self)  # pyright: ignore[reportArgumentType]
         try:
             cls.__init__(self, *args, **kwargs)  # pyright: ignore[reportCallIssue]
         finally:
-            _currently_initialising.remove(self)
+            _currently_initialising.remove(self)  # pyright: ignore[reportArgumentType]
 
         # Reject a field left unset by a buggy __init__. equinox raises the same
         # error via a `dir(self)` scan; without it the instance would flatten to a

--- a/tests/unit/test_fast_module.py
+++ b/tests/unit/test_fast_module.py
@@ -6,6 +6,8 @@ invariants, static fields, pytree flatten/unflatten, and abstract-instantiation
 errors. It must also degrade gracefully when its fast path is unavailable.
 """
 
+import typing
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -145,6 +147,23 @@ def test_converter_is_applied():
     assert jnp.array_equal(v.array, jnp.asarray([1.0, 2.0, 3.0]))
 
 
+def test_call_returns_concrete_type_not_any():
+    """`_FastModuleMeta.__call__` must be generic (`-> _T`), not `-> Any`.
+
+    A static checker uses the metaclass `__call__` return type for a construction
+    expression, so a plain ``-> Any`` would erase the
+    `dataclass_transform`-synthesised signature and make ``MyValue(...)`` type as
+    ``Any`` for every `Value` subclass -- silently dropping downstream typing (e.g.
+    ``unxt.Quantity(1, "m")`` inferring `Any`).
+
+    Asserted at runtime (the pyright hook excludes ``tests/``, so a static
+    ``assert_type`` here would not be CI-enforced): the return annotation must be a
+    ``TypeVar`` bound to the class, not ``Any``.
+    """
+    ret = typing.get_type_hints(_FastModuleMeta.__call__).get("return")
+    assert isinstance(ret, typing.TypeVar), ret
+
+
 class _Checked(quax.ArrayValue):
     data: jax.Array
     scale: float = eqx.field(static=True)
@@ -186,7 +205,10 @@ def test_static_field_and_pytree_roundtrip():
 def test_abstract_instantiation_still_errors():
     """Abstract Values cannot be instantiated (equinox's error is preserved)."""
     with pytest.raises(TypeError):
-        quax.ArrayValue()  # abstract: aval/materialise unimplemented
+        # Deliberately instantiate the abstract class to check the runtime error.
+        # pyright now (correctly) flags this since `__call__` types construction as
+        # the concrete class rather than `Any`.
+        quax.ArrayValue()  # pyright: ignore[reportAbstractUsage]
 
 
 class _WithNew(quax.ArrayValue):


### PR DESCRIPTION
## Summary

`_FastModuleMeta.__call__` (added in v0.4.0 for the fast construction path) is typed `-> Any`. A static type checker uses the **metaclass `__call__` return type** for a construction expression, so `-> Any` erases the `dataclass_transform`-synthesised signature for **every** `quax.Value` / `ArrayValue` subclass:

```python
reveal_type(Unitful(x, {meters: 1}))   # before: Any    after: Unitful
```

This silently drops all downstream typing built on a `Value`. It surfaced in [`unxt`](https://github.com/GalacticDynamics/unxt): `AbstractQuantity` subclasses `quax.ArrayValue`, so `unxt.Quantity(1, "m")` — and every quax Module subclass — inferred `Any`, and pyright checked nothing constructed from a Value. (This is the construction-typing sibling of #196, which restored the `dataclass_transform` marker itself; #196 fixed `__init__` synthesis, but the metaclass `__call__ -> Any` still shadowed it at the call site.)

## Fix

Make the metaclass call generic:

```python
def __call__(cls: type[_T], *args: Any, **kwargs: Any) -> _T:
```

so construction types as the concrete class.

Notes on the details:
- **`_T` is left unbounded.** A bound — even `eqx.Module` — makes `type[_T]` too narrow to annotate a metaclass `cls` parameter (pyright: *"must be a supertype of its class `_FastModuleMeta`"*).
- **Internal `self` stays `Any`** (unchanged). After the `isinstance(self, cls)` check it narrows to the unbounded `_T`; the two `_currently_initialising` init-guard calls therefore carry a local `# pyright: ignore[reportArgumentType]` (the object *is* an `eqx.Module` at runtime, but unbounded `_T` can't express that without re-introducing the metaclass-`cls` friction above).
- **`super().__call__`** is typed `Any | None` by equinox, so it is `cast(_T, ...)` on the abstract/fallback path.

No runtime change.

## Test

`test_call_returns_concrete_type_not_any` asserts the `__call__` return annotation is a `TypeVar`, not `Any`. It's **runtime-introspected** on purpose: the `pyright` pre-commit hook has `exclude: "^tests/.*"`, so a static `assert_type` in a test would not be CI-enforced — whereas this assertion runs under `pytest` (and thus in the CI `Test` job). The existing abstract-instantiation test gains a `# pyright: ignore[reportAbstractUsage]`, since pyright now (correctly) type-checks `quax.ArrayValue()` instead of seeing `Any`.

## Verification

- `prek run pyright` (the CI Lint hook, `src/quax`) — **passes**, 0 errors
- `pytest` — full suite green; `tests/unit/test_fast_module.py` 17 passed
- `ruff check` / `ruff format` — clean
- Confirmed the guard bites: reverting to `-> Any` fails the new test, and `Unitful(...)` reverts to `Any`

🤖 Generated with [Claude Code](https://claude.com/claude-code)