### PR TITLE
🐛 fix(compat): don't reintroduce `scan_p`'s removed `linear` param

### DIFF
--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -130,20 +130,23 @@ else:
     ) -> dict[str, Any]:
         """Parameters for re-binding `scan_p` with the given group sizes.
 
-        `linear` is a per-operand flag tuple (consts + carry + xs). Quaxifying
-        the body can change the flat operand count -- a single `ArrayValue` may
-        flatten to several arrays -- in which case the incoming `linear` no
-        longer lines up with the new operands and JAX's scan rules raise.
+        `linear` is a per-operand flag tuple (consts + carry + xs), dropped from
+        `scan_p` in JAX 0.10.2. Quaxifying the body can change the flat operand
+        count -- a single `ArrayValue` may flatten to several arrays -- in which
+        case the incoming `linear` no longer lines up with the new operands and
+        JAX's scan rules raise.
 
-        Only rebuild `linear` when the operand count actually changed. When it
-        matches (the common single-leaf case), keep JAX's original linearity
-        analysis so `lax.scan`'s AD does not lose it to an all-`False` rebuild.
+        Only rebuild `linear` when it is present *and* the operand count actually
+        changed. When it matches (the common single-leaf case), keep JAX's
+        original linearity analysis so `lax.scan`'s AD does not lose it to an
+        all-`False` rebuild; when JAX no longer takes the parameter, never
+        reintroduce it.
         """
         del num_ys
         new_params = {**params, "num_consts": num_consts, "num_carry": num_carry}
         n_operands = num_consts + num_carry + num_xs
         linear = params.get("linear")
-        if linear is None or len(linear) != n_operands:
+        if linear is not None and len(linear) != n_operands:
             # Operand count changed: the old per-operand flags no longer align.
             # The body is retraced from scratch, so no linearity carries over.
             new_params["linear"] = (False,) * n_operands


### PR DESCRIPTION
## What

Weekly CI failed on Python 3.11 ([run 30799278862](https://github.com/nstarman/quax/actions/runs/30799278862)) with 11 scan tests erroring:

```
TypeError: _scan_abstract_eval() got an unexpected keyword argument 'linear'
```

Python 3.11 resolves to `jax==0.10.2`, which dropped `linear` from `scan_p`'s parameters (3.13/3.14 get 0.11.x, which takes the `ft_in`/`ft_out` path and was unaffected).

`scan_bind_params`' pre-0.11 branch conflated "no `linear` in params" with "`linear` no longer aligns with the new operand count" and injected an all-`False` tuple in both cases — reintroducing a parameter JAX no longer accepts.

## Fix

Rebuild `linear` only when it is *present* and misaligned. Backward compatible: JAX < 0.10.2 still gets its original linearity analysis preserved (and rebuilt when quaxifying changes the flat operand count).

## Verification

- `jax==0.10.2` on Python 3.11 (the failing config): full suite `1045 passed, 142 skipped, 37 xfailed, 6 xpassed` — the 11 previously-failing scan tests now pass.
- `jax==0.8.1` (local floor-ish): scan tests pass, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)