### PR TITLE
Backport PR #205 on branch versions/v0.3.x (🐛 fix(compat): don't reintroduce `scan_p`'s removed `linear` param)

### DIFF
--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -134,9 +134,29 @@ else:
         num_xs: int,
         num_ys: int,
     ) -> dict[str, Any]:
-        """Parameters for re-binding `scan_p` with the given group sizes."""
-        del num_xs, num_ys
-        return {**params, "num_consts": num_consts, "num_carry": num_carry}
+        """Parameters for re-binding `scan_p` with the given group sizes.
+
+        `linear` is a per-operand flag tuple (consts + carry + xs), dropped from
+        `scan_p` in JAX 0.10.2. Quaxifying the body can change the flat operand
+        count -- a single `ArrayValue` may flatten to several arrays -- in which
+        case the incoming `linear` no longer lines up with the new operands and
+        JAX's scan rules raise.
+
+        Only rebuild `linear` when it is present *and* the operand count actually
+        changed. When it matches (the common single-leaf case), keep JAX's
+        original linearity analysis so `lax.scan`'s AD does not lose it to an
+        all-`False` rebuild; when JAX no longer takes the parameter, never
+        reintroduce it.
+        """
+        del num_ys
+        new_params = {**params, "num_consts": num_consts, "num_carry": num_carry}
+        n_operands = num_consts + num_carry + num_xs
+        linear = params.get("linear")
+        if linear is not None and len(linear) != n_operands:
+            # Operand count changed: the old per-operand flags no longer align.
+            # The body is retraced from scratch, so no linearity carries over.
+            new_params["linear"] = (False,) * n_operands
+        return new_params
 
 
 typeof: Callable[[Any], Any]

--- a/src/quax/examples/unitful/_core.py
+++ b/src/quax/examples/unitful/_core.py
@@ -16,6 +16,15 @@ class Dimension:
     def __repr__(self):
         return self.name
 
+    def __lt__(self, other):
+        # `units` is a dict keyed by `Dimension`, and JAX sorts dict keys when
+        # flattening a pytree -- which equinox does to every `Module.__init__`
+        # argument. Without an ordering, any multi-dimension `Unitful` (e.g.
+        # `{meters: 1, seconds: -1}`) fails to construct.
+        if not isinstance(other, Dimension):
+            return NotImplemented
+        return self.name < other.name
+
 
 kilograms = Dimension("kg")
 meters = Dimension("m")


### PR DESCRIPTION
Manual backport of #205 (MrMeeseeks reported a conflict).

## Conflict resolution

`versions/v0.3.x` never had the `linear` handling at all — the rebuild was introduced on `main` by #189 ("support multi-leaf Values and empty scans"), which was not backported. So the conflict is `main`'s two-commit history vs. this branch's plain pass-through.

Resolved by taking the **net effect** of #205 on `scan_bind_params` only:

- rebuild `linear` when it is present *and* the operand count changed (the #189 fix this branch lacks — quaxifying can change the flat operand count, and a stale per-operand tuple makes JAX's scan rules raise);
- never inject `linear` when JAX no longer takes it (the #205 fix; JAX 0.10.2 dropped the parameter).

The cherry-pick would also have dragged in unrelated `main`-only changes to `_compat.py` (import reordering, dropping the `JAX_GE_0_7_0` / `pjit_p` fallback, comment rewraps). Those are **excluded** — this branch still supports `jax>=0.5.3` and Python 3.10, where the `pjit_p` fallback is required.

## Note on scope

This branch was **not** hit by the weekly-CI failure that motivated #205: its pass-through never added `linear`, so `TypeError: _scan_abstract_eval() got an unexpected keyword argument 'linear'` does not occur here (verified — scan tests pass on `versions/v0.3.x` @ b365e08 with `jax==0.10.2`). The backport keeps the two branches consistent and brings the operand-count-misalignment guard across.

## Verification

All on Python 3.11:

- `jax==0.10.2`, scan tests: 9 passed.
- `jax==0.10.2`, full suite: `1 failed, 967 passed, 137 skipped, 58 xfailed, 6 xpassed`. The one failure, `tests/usage/test_unitful.py::test_integer_pow_units_and_values_agree`, is **pre-existing on b365e08** with this JAX (confirmed on the unmodified base) and unrelated to scan.
- `jax==0.6.2` (exercises the `linear`-present path), scan tests: 9 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)