### PR TITLE
build(deps): pin beartype<0.23.0 to avoid plum resolver breakage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,14 @@ docs = [
 ]
 ide = ["ipykernel>=7.2.0"]
 lint = ["prek>=0.3.11", "ruff>=0.15.9"]
-tests = ["beartype>=0.20.2", "pytest>=8.3.5", "pytest-env>=1.1.5", "jax[cpu]"]
+tests = [
+  # beartype>=0.23.0rc0 breaks plum's method-redefinition detection:
+  # https://github.com/beartype/plum/issues/295, fix in https://github.com/beartype/plum/pull/296 (unmerged).
+  "beartype>=0.20.2,<0.23.0",
+  "pytest>=8.3.5",
+  "pytest-env>=1.1.5",
+  "jax[cpu]",
+]
 # Performance benchmarks. Kept out of `dev`/`tests` so the default suite never
 # collects them (see tests/benchmark/conftest.py). Run locally with
 # `uv run --group bench pytest tests/benchmark --benchmark-only`; CI runs them

--- a/uv.lock
+++ b/uv.lock
@@ -1463,7 +1463,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 bench = [
-    { name = "beartype", specifier = ">=0.20.2" },
+    { name = "beartype", specifier = ">=0.20.2,<0.23.0" },
     { name = "jax", extras = ["cpu"] },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
@@ -1471,7 +1471,7 @@ bench = [
     { name = "pytest-env", specifier = ">=1.1.5" },
 ]
 dev = [
-    { name = "beartype", specifier = ">=0.20.2" },
+    { name = "beartype", specifier = ">=0.20.2,<0.23.0" },
     { name = "hippogriffe", specifier = "==0.2.2" },
     { name = "jax", extras = ["cpu"] },
     { name = "mkdocstrings", extras = ["python"], specifier = "==1.0.6" },
@@ -1496,7 +1496,7 @@ lint = [
     { name = "ruff", specifier = ">=0.15.9" },
 ]
 tests = [
-    { name = "beartype", specifier = ">=0.20.2" },
+    { name = "beartype", specifier = ">=0.20.2,<0.23.0" },
     { name = "jax", extras = ["cpu"] },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-env", specifier = ">=1.1.5" },


### PR DESCRIPTION
## Summary

CI's "Pre-release deps" job is failing because `beartype==0.23.0rc0` breaks `plum`'s method-redefinition detection, which silently deletes registered methods (including plum's own identity-conversion fallback) and causes `plum.convert()` to raise `NotFoundLookupError`. See the failing job: [Pre-release deps (Python 3.11)](https://github.com/nstarman/quax/actions/runs/32000273902/job/95299139245).

```
plum._resolver.NotFoundLookupError: `_convert(jaxlib._jax.ArrayImpl, jax.jaxlib._jax.Array)` could not be resolved.
```

Root cause: since `beartype>=0.23.0rc0`, `beartype.door.TypeHint(Any) == TypeHint(T)` is `True` for every `T` (an intentional, upstream-endorsed change for `Any`-assignability semantics). `plum` uses that equality to detect "this new method redefines an existing one" during registration, so the very first unannotated method registered on any dispatcher gets silently overwritten by the next concretely-typed one — no warning, no error.

- Plum issue: [beartype/plum#295](https://github.com/beartype/plum/issues/295)
- Plum fix PR (open, unmerged): [beartype/plum#296](https://github.com/beartype/plum/pull/296)

This pins `beartype<0.23.0` in the `tests` dependency group until the plum fix lands and quax can pick up a plum release that includes it. The current stable `beartype` release (`0.22.9`) is unaffected, so this only changes what the "pre-release deps" CI job installs.

## Test plan
- [x] `uv lock` regenerated cleanly with the new constraint (resolves to `beartype==0.22.9`)
- [x] Local test run confirms `beartype==0.22.9` is installed