### PR TITLE
✅ test(bench): cover autodiff, quaxify overhead, and materialise fallback

### DIFF
--- a/tests/benchmark/test_autodiff.py
+++ b/tests/benchmark/test_autodiff.py
@@ -1,0 +1,78 @@
+"""Benchmarks for the autodiff path through a quax trace.
+
+``_QuaxTrace.process_custom_jvp_call`` and its two ``lu.transformation_with_aux``
+wrappers (``_custom_jvp_fun_wrap`` / ``_custom_jvp_jvp_wrap``) are the only
+``process_*`` override besides ``process_primitive``, and had no benchmark
+coverage at all. They do noticeably more per call than plain dispatch --
+flatten/unflatten of every `Value` through a treedef, the `SymbolicZero`
+promotion scan over the tangents, and the primal/tangent `materialise` fallback
+when the two come back as different classes -- so a regression there is invisible
+to the ``test_dispatch`` benchmarks.
+
+`test_lora_mlp_grad` is the end-to-end version: `filter_grad` over a loraified
+MLP under `jax.jit`, i.e. the workload quax's flagship example actually exists
+for. It is warmed and jitted, so it measures the steady-state re-trace + compiled
+call, not compilation.
+"""
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+import quax
+from quax.examples import lora
+
+from ..unit.myarray import MyArray
+
+
+@jax.custom_jvp
+def _custom_jvp_fn(x):
+    return jnp.sin(x)
+
+
+@_custom_jvp_fn.defjvp
+def _custom_jvp_fn_jvp(primals, tangents):
+    (x,) = primals
+    (x_dot,) = tangents
+    return jnp.sin(x), jnp.cos(x) * x_dot
+
+
+_xm = MyArray(jnp.arange(8.0) + 1)
+
+
+@pytest.mark.benchmark(group="autodiff")
+def test_custom_jvp_forward(benchmark):
+    """`quaxify` over a `custom_jvp` function — `process_custom_jvp_call` +
+    `_custom_jvp_fun_wrap` (forward only; the jvp rule is never entered)."""
+    qfn = quax.quaxify(_custom_jvp_fn)
+    qfn(_xm)  # warm the dispatch cache
+    benchmark(lambda: qfn(_xm))
+
+
+@pytest.mark.benchmark(group="autodiff")
+def test_custom_jvp_grad(benchmark):
+    """`quaxify(grad(custom_jvp fn))` — additionally exercises
+    `_custom_jvp_jvp_wrap`: the tangent `SymbolicZero` scan and the
+    primal/tangent class reconciliation."""
+    qfn = quax.quaxify(eqx.filter_grad(lambda a: jnp.sum(_custom_jvp_fn(a))))
+    qfn(_xm)
+    benchmark(lambda: qfn(_xm))
+
+
+_key = jr.PRNGKey(0)
+_mlp = lora.loraify(
+    eqx.nn.MLP(8, 8, 32, 2, activation=jax.nn.relu, key=_key), rank=4, key=_key
+)
+_vector = jr.normal(_key, (8,))
+
+
+@pytest.mark.benchmark(group="autodiff")
+def test_lora_mlp_grad(benchmark):
+    """`jit(grad(quaxify(...)))` over a loraified MLP — the end-to-end LoRA
+    training step. `jax.nn.relu` is a `custom_jvp`, so this covers the autodiff
+    path together with LoRA's `dot_general` rule."""
+    run = eqx.filter_jit(eqx.filter_grad(quax.quaxify(lambda m, x: jnp.sum(m(x)))))
+    run(_mlp, _vector)  # compile, and fill the quax caches
+    benchmark(lambda: jax.block_until_ready(run(_mlp, _vector)))

--- a/tests/benchmark/test_dispatch.py
+++ b/tests/benchmark/test_dispatch.py
@@ -18,7 +18,7 @@ import pytest
 from jax import lax
 
 import quax
-from quax.examples import lora, zero
+from quax.examples import lora, unitful, zero
 
 from ..unit.myarray import MyArray
 
@@ -31,11 +31,21 @@ _ym = MyArray(jnp.arange(8.0) + 2)
 _z = zero.Zero((8,), jnp.float32)
 _arr = jnp.arange(8.0)
 
+# A `Value` whose rules do non-trivial Python work per primitive (dict compare /
+# merge of the units), rather than just rewrapping arrays.
+_u = unitful.Unitful(jnp.arange(8.0) + 1, unitful.meters)
+
 # LoRA: a low-rank array times a dense matrix (heavy dispatch — the matmul
 # expands to several primitives, several of which are inlined pjits).
 _lora = lora.LoraArray(jax.random.normal(_key, (32, 16)), rank=4, key=_key)
 _rhs = jax.random.normal(_key, (16, 8))
 _dot_dn = (((1,), (0,)), ((), ()))
+
+# The same LoRA array, but materialisable: `sin` has no LoRA rule, so it falls
+# through to `_default_process` -> `Value.default` -> `materialise`.
+_lora_mat = lora.LoraArray(
+    jax.random.normal(_key, (32, 16)), rank=4, key=_key, allow_materialise=True
+)
 
 
 # An inner `@jax.jit` that quax does *not* inline, so its `pjit` takes the cached
@@ -74,6 +84,21 @@ def test_mul_myarray(benchmark):
 def test_add_zero(benchmark):
     """`quaxify(add)(Zero, array)` — the symbolic-zero fast rule."""
     _bench(benchmark, lambda a, b: a + b, _z, _arr)
+
+
+@pytest.mark.benchmark(group="dispatch")
+def test_mul_unitful(benchmark):
+    """`quaxify(mul)(Unitful, Unitful)` — a rule that does real Python work
+    (merging the unit dicts) on top of the array op."""
+    _bench(benchmark, lambda a, b: a * b, _u, _u)
+
+
+@pytest.mark.benchmark(group="dispatch")
+def test_materialise_fallback(benchmark):
+    """`quaxify(sin)(LoraArray)` — no rule for this (primitive, type), so the
+    cached `_DISPATCH_MISS` sends it to `_default_process`, which materialises
+    every `Value` operand and binds the primitive on plain arrays."""
+    _bench(benchmark, jnp.sin, _lora_mat)
 
 
 @pytest.mark.benchmark(group="dispatch")

--- a/tests/benchmark/test_quaxify.py
+++ b/tests/benchmark/test_quaxify.py
@@ -1,0 +1,63 @@
+"""Benchmarks for `_Quaxify.__call__`'s per-call overhead.
+
+The other suites all measure *per-primitive* cost with a fixed, tiny argument
+pytree. This one measures what `quaxify` charges before and after the traced
+function runs, which is per-*call* and scales with the argument pytree rather
+than with the number of primitives:
+
+- the no-`Value` short-circuit (`_is_value` over every leaf of `(fn, args,
+  kwargs)`, then straight through to `self.fn`) — pure tax on quaxified code
+  called with plain arrays;
+- `_partition_and_wrap`'s general branch, taken whenever `filter_spec is not
+  True`, which pays `eqx.partition` + `eqx.combine` on top of the `tree_map` the
+  fast branch does alone;
+- wrapping/unwrapping a wide pytree of `Value`s, where the two `tree_map` passes
+  (in `_partition_and_wrap` and over the output) dominate.
+
+None of these paths were covered before; a regression in any of them is
+invisible to a benchmark that passes two arrays and one primitive.
+"""
+
+import jax.numpy as jnp
+import pytest
+
+import quax
+
+from ..unit.myarray import MyArray
+
+
+_arr = jnp.arange(8.0)
+_xm = MyArray(_arr)
+_ym = MyArray(_arr + 1)
+
+
+@pytest.mark.benchmark(group="quaxify")
+def test_no_value_shortcut(benchmark):
+    """`quaxify(f)(array)` with no `Value` anywhere — the short-circuit that
+    skips the trace entirely, leaving only the `tree_leaves` scan."""
+    qfn = quax.quaxify(lambda a, b: a + b)
+    qfn(_arr, _arr)
+    benchmark(lambda: qfn(_arr, _arr))
+
+
+@pytest.mark.benchmark(group="quaxify")
+def test_filter_spec_partition(benchmark):
+    """`quaxify(..., filter_spec=False)` — `_partition_and_wrap`'s general
+    branch (`eqx.partition` + `eqx.combine`), passing the `Value`s through to a
+    nested `quaxify` (the redispatch pattern)."""
+    inner = quax.quaxify(lambda a, b: a + b)
+    outer = quax.quaxify(lambda a, b: inner(a, b), filter_spec=False)
+    outer(_xm, _ym)
+    benchmark(lambda: outer(_xm, _ym))
+
+
+_tree = [MyArray(_arr) for _ in range(32)]
+
+
+@pytest.mark.benchmark(group="quaxify")
+def test_wide_pytree(benchmark):
+    """32 `Value`s in one argument pytree — the `tree_map` wrap/unwrap passes,
+    plus 32 primitives' worth of dispatch."""
+    qfn = quax.quaxify(lambda ts: [a + a for a in ts])
+    qfn(_tree)
+    benchmark(lambda: qfn(_tree))


### PR DESCRIPTION
Fills three gaps in `tests/benchmark/` — code paths that had **zero** benchmark coverage.

### 1. Autodiff — `tests/benchmark/test_autodiff.py`

`_QuaxTrace.process_custom_jvp_call` and its two `lu.transformation_with_aux` wrappers (`_custom_jvp_fun_wrap` / `_custom_jvp_jvp_wrap`) are the only `process_*` override besides `process_primitive`, and do noticeably more per call than plain dispatch: flatten/unflatten of every `Value` through a treedef, the `SymbolicZero` promotion scan over the tangents, and the primal/tangent `materialise` fallback when the two come back as different classes. A regression there was invisible to `test_dispatch`.

- `test_custom_jvp_forward` — forward only, jvp rule never entered
- `test_custom_jvp_grad` — adds `_custom_jvp_jvp_wrap`
- `test_lora_mlp_grad` — `jit(grad(quaxify(...)))` over a loraified MLP, i.e. the workload the flagship example exists for. `jax.nn.relu` is a `custom_jvp`, so this covers autodiff together with LoRA's `dot_general` rule.

### 2. Per-call `quaxify` overhead — `tests/benchmark/test_quaxify.py`

Every existing benchmark passes two arguments and one primitive, so the suite only ever measured per-*primitive* cost. These paths scale with the argument pytree instead:

- `test_no_value_shortcut` — the no-`Value` short-circuit (`_is_value` over every leaf, then straight through to `self.fn`): pure tax on quaxified code called with plain arrays
- `test_filter_spec_partition` — `_partition_and_wrap`'s general branch (`eqx.partition` + `eqx.combine`), taken whenever `filter_spec is not True`
- `test_wide_pytree` — 32 `Value`s in one argument pytree, where the wrap/unwrap `tree_map` passes dominate

### 3. Dispatch fallback — `tests/benchmark/test_dispatch.py`

- `test_materialise_fallback` — every dispatch benchmark hit a registered rule, so the cached-`_DISPATCH_MISS` → `_default_process` → `Value.default` → `materialise` path was never timed
- `test_mul_unitful` — a rule that does real Python work per primitive (merging the unit dicts) rather than only rewrapping arrays

### Not included

- **Cold-path / cache-miss benchmarks.** pytest-benchmark's repeat loop fights per-round cache clearing; needs a custom fixture. Worth adding when first-call latency becomes a complaint.
- **Per-example-type coverage** for `sparse` / `named` / `prng` / `structured_matrices` — same dispatch machinery as the types already covered, no new code path.

### Verification

```
uv run --group bench pytest tests/benchmark --benchmark-only   # 14 new/changed pass
uv run --group bench pytest tests -q --co                       # 0 benchmarks collected — conftest gating intact
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)