### PR TITLE
feat: support `jax.custom_vjp` under `quaxify`

### DIFF
--- a/.github/prompts/add-jax-primitive.prompt.md
+++ b/.github/prompts/add-jax-primitive.prompt.md
@@ -19,11 +19,12 @@ Register a new JAX primitive handler for the `$input` operation.
 
    ```python
    @quax.register(lax.<primitive>_p)
-   def _(x: MyType, ...) -> MyType:
+   def <primitive>_<mytype>(x: MyType, ...) -> MyType:
        # implement using x.array, x.shape, x.dtype, etc.
        ...
    ```
 
+   - Name the function after the primitive and the types it dispatches on (`add_meters_meters`, `mul_meters_arraylike`) — never `def _`, which makes every rule indistinguishable in tracebacks and in plum's ambiguity errors
    - Keep keyword-only params as `**kw` if the primitive may pass extra args (e.g. `out_dtype` for `mul_p`)
    - Forward unknown kwargs to the underlying JAX op when doing a materialised fallback
 
@@ -31,7 +32,7 @@ Register a new JAX primitive handler for the `$input` operation.
 
    ```python
    @quax.register(lax.<primitive>_p, precedence=1)
-   def _(x: MyType, y: MyType) -> MyType:
+   def <primitive>_<mytype>_<mytype>(x: MyType, y: MyType) -> MyType:
        ...
    ```
 

--- a/.github/prompts/add-jax-primitive.prompt.md
+++ b/.github/prompts/add-jax-primitive.prompt.md
@@ -24,7 +24,7 @@ Register a new JAX primitive handler for the `$input` operation.
        ...
    ```
 
-   - Name the function after the primitive and the types it dispatches on (`add_meters_meters`, `mul_meters_arraylike`) — never `def _`, which makes every rule indistinguishable in tracebacks and in plum's ambiguity errors
+   - Name the function after the primitive and the types it dispatches on (`add_meters_meters`, `mul_meters_array_like`) — never `def _`, which makes every rule indistinguishable in tracebacks and in plum's ambiguity errors
    - Keep keyword-only params as `**kw` if the primitive may pass extra args (e.g. `out_dtype` for `mul_p`)
    - Forward unknown kwargs to the underlying JAX op when doing a materialised fallback
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
           python-version: ${{ needs.setup.outputs.newest-python }}
 
       - name: Install
-        run: uv sync --no-default-groups --group integration --locked
+        run: uv sync --no-default-groups --group test-integration --locked
 
       - name: Test with pytest
         run: uv run --frozen pytest tests/integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,30 @@ jobs:
       - name: Test package
         run: uv run --no-sync pytest
 
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    needs: [lint, setup]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: ${{ needs.setup.outputs.newest-python }}
+
+      - name: Install
+        run: uv sync --no-default-groups --group integration --locked
+
+      - name: Test with pytest
+        run: uv run --frozen pytest tests/integration
+
   ci-pass:
     name: CI Pass
     runs-on: ubuntu-latest
-    needs: [lint, setup, tests, oldest-supported, newest-supported]
+    needs: [lint, setup, tests, oldest-supported, newest-supported, integration]
     if: always()
     steps:
       - name: All required jobs passed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ Tests use `(func_name, args, kw, expect_myarray)` parameter tuples. Common marks
 
 - **`eqx.field(static=True)` is mandatory** for shapes, dtypes, and bool flags — forget it and JAX will attempt to trace through them.
 - **`materialise()` may intentionally raise** — `MyArray.materialise()` (test fixture) and `LoraArray.materialise()` raise on purpose; do not "fix" them.
+- **Name every registered rule** — `@quax.register` handlers are named after the primitive and the
+  types they dispatch on (`add_unitful_unitful`, `convert_element_type_zero`, `cond_quax`), never
+  `def _`. Dispatch ignores the name; tracebacks, plum's ambiguity errors, and profiles do not.
 - **`_DenseArrayValue` is internal** — never instantiate or reference it from user code.
 - **`_compat.py` version gates** — use `typeof` from `_compat` (not `jax.core.get_aval` directly); `_primitives.py` and `_compat.py` carry dual branches for JAX API differences across versions.
 - **Tests import across modules** — e.g. `from ..myarray import MyArray`; keep internal test imports relative.

--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ written into such a buffer come back out as plain arrays.
 
 Another: forward-mode `quaxify` works through `custom_vjp`-based libraries
 (e.g. `diffrax`), and ordinary `custom_vjp` differentiates fine under
-`jax.grad`, but reverse-mode through Equinox's `filter_custom_vjp` -- which
-`equinox.internal.while_loop` (and so `diffrax`) is built on -- is not yet
-supported.
+`jax.grad`, but reverse-mode through a library built on
+`equinox.internal.while_loop` (and so `diffrax`) currently runs into the
+buffer limitation above, and a second, independent gap sits behind it -- so
+fixing buffers alone would not be enough to make this differentiate.
 
 ## See also: other libraries in the JAX ecosystem
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ One known limitation: Quax cannot see arrays that a library pre-allocates
 without reference to your `Value` (e.g. a `jnp.zeros` scratch buffer). Values
 written into such a buffer come back out as plain arrays.
 
+Another: forward-mode `quaxify` works through `custom_vjp`-based libraries
+(e.g. `diffrax`), and ordinary `custom_vjp` differentiates fine under
+`jax.grad`, but reverse-mode through Equinox's `filter_custom_vjp` -- which
+`equinox.internal.while_loop` (and so `diffrax`) is built on -- is not yet
+supported.
+
 ## See also: other libraries in the JAX ecosystem
 
 **Always useful**  

--- a/README.md
+++ b/README.md
@@ -83,13 +83,15 @@ quax.quaxify(run)(lora_linear, vector)
 lora_linear = lora.loraify(linear, rank=2, key=key3)
 ```
 
-## Work in progress!
+## Supported JAX features
 
-Right now, the following are not supported:
+Quax handles `jax.custom_jvp`, `jax.custom_vjp`, `jax.lax.cond_p`,
+`jax.lax.while_p`, and `jax.lax.scan_p`. If you hit a JAX transform or
+primitive that Quax does not understand, open an issue or pull request.
 
-- `jax.custom_vjp`
-
-It should be fairly straightforward to add support for these; open an issue or pull request. (We've already got `jax.custom_jvp`, `jax.lax.cond_p`, `jax.lax.while_p`, and `jax.lax.scan_p`. :) )
+One known limitation: Quax cannot see arrays that a library pre-allocates
+without reference to your `Value` (e.g. a `jnp.zeros` scratch buffer). Values
+written into such a buffer come back out as plain arrays.
 
 ## See also: other libraries in the JAX ecosystem
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,13 +50,13 @@ docs = [
   "zensical",
 ]
 ide = ["ipykernel>=7.2.0"]
+lint = ["prek>=0.3.11", "ruff>=0.15.9"]
 # Integration tests against downstream JAX libraries (tests/integration). Kept
 # out of `dev`/`tests` so the default suite neither installs nor depends on
 # them; the modules skip themselves when the dependency is missing. Run locally
-# with `uv run --group integration pytest tests/integration`; CI runs them in a
-# dedicated job.
-integration = [{ include-group = "tests" }, "diffrax>=0.7.2"]
-lint = ["prek>=0.3.11", "ruff>=0.15.9"]
+# with `uv run --group test-integration pytest tests/integration`; CI runs them
+# in a dedicated job.
+test-integration = [{ include-group = "tests" }, "diffrax>=0.7.2"]
 tests = [
   # beartype>=0.23.0rc0 breaks plum's method-redefinition detection:
   # https://github.com/beartype/plum/issues/295, fix in https://github.com/beartype/plum/pull/296 (unmerged).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,12 @@ docs = [
   "zensical",
 ]
 ide = ["ipykernel>=7.2.0"]
+# Integration tests against downstream JAX libraries (tests/integration). Kept
+# out of `dev`/`tests` so the default suite neither installs nor depends on
+# them; the modules skip themselves when the dependency is missing. Run locally
+# with `uv run --group integration pytest tests/integration`; CI runs them in a
+# dedicated job.
+integration = [{ include-group = "tests" }, "diffrax>=0.7.2"]
 lint = ["prek>=0.3.11", "ruff>=0.15.9"]
 tests = [
   # beartype>=0.23.0rc0 breaks plum's method-redefinition detection:

--- a/skills/quax/SKILL.md
+++ b/skills/quax/SKILL.md
@@ -179,7 +179,7 @@ everything you debug with does: tracebacks, `plum` ambiguity and redefinition
 errors, and profiles all identify a rule by its function name, and a module of
 rules all called `_` makes every one of them indistinguishable. Name it after
 the primitive and the types it dispatches on — `add_meters_meters`,
-`mul_meters_arraylike`, `select_n_unitful` — matching the existing
+`mul_meters_array_like`, `select_n_unitful` — matching the existing
 `convert_element_type_zero` in `quax.examples.zero` and `cond_quax` in
 `quax._primitives`.
 
@@ -200,11 +200,11 @@ operand you do not own:
 
 ```python
 @quax.register(lax.mul_p)
-def mul_meters_arraylike(x: Meters, y: ArrayLike, /, **kw) -> Meters:
+def mul_meters_array_like(x: Meters, y: ArrayLike, /, **kw) -> Meters:
     return Meters(lax.mul_p.bind(x.array, y, **kw))
 
 @quax.register(lax.mul_p)
-def mul_arraylike_meters(x: ArrayLike, y: Meters, /, **kw) -> Meters:
+def mul_array_like_meters(x: ArrayLike, y: Meters, /, **kw) -> Meters:
     return Meters(lax.mul_p.bind(x, y.array, **kw))
 ```
 

--- a/skills/quax/SKILL.md
+++ b/skills/quax/SKILL.md
@@ -121,7 +121,7 @@ class Meters(quax.ArrayValue):
         raise ValueError("Refusing to materialise Meters: it would drop the unit.")
 
 @quax.register(lax.add_p)
-def _(x: Meters, y: Meters) -> Meters:
+def add_meters_meters(x: Meters, y: Meters) -> Meters:
     return Meters(x.array + y.array)
 
 quax.quaxify(jnp.add)(Meters(jnp.arange(3.0)), Meters(jnp.ones(3)))
@@ -172,7 +172,16 @@ lists/scalars without writing `__init__`.
 
 `@quax.register(primitive)` takes the `jax.extend.core.Primitive`, and dispatches
 on the **type annotations** — plum reads them, so they are load-bearing, not
-documentation. The function name is irrelevant; `def _(...)` is idiomatic.
+documentation.
+
+**Name the rule; never `def _(...)`.** Dispatch does not read the name, but
+everything you debug with does: tracebacks, `plum` ambiguity and redefinition
+errors, and profiles all identify a rule by its function name, and a module of
+rules all called `_` makes every one of them indistinguishable. Name it after
+the primitive and the types it dispatches on — `add_meters_meters`,
+`mul_meters_arraylike`, `select_n_unitful` — matching the existing
+`convert_element_type_zero` in `quax.examples.zero` and `cond_quax` in
+`quax._primitives`.
 
 Find the primitive behind a `jnp` function by tracing it:
 
@@ -191,11 +200,11 @@ operand you do not own:
 
 ```python
 @quax.register(lax.mul_p)
-def _(x: Meters, y: ArrayLike, /, **kw) -> Meters:
+def mul_meters_arraylike(x: Meters, y: ArrayLike, /, **kw) -> Meters:
     return Meters(lax.mul_p.bind(x.array, y, **kw))
 
 @quax.register(lax.mul_p)
-def _(x: ArrayLike, y: Meters, /, **kw) -> Meters:
+def mul_arraylike_meters(x: ArrayLike, y: Meters, /, **kw) -> Meters:
     return Meters(lax.mul_p.bind(x, y.array, **kw))
 ```
 
@@ -214,7 +223,7 @@ raises `AmbiguousLookupError`. Fix it by adding the specific rule with
 
 ```python
 @quax.register(lax.mul_p, precedence=1)
-def _(x: Meters, y: Meters, /, **kw) -> Meters:
+def mul_meters_meters(x: Meters, y: Meters, /, **kw) -> Meters:
     return Meters(lax.mul_p.bind(x.array, y.array, **kw))
 ```
 

--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -161,13 +161,9 @@ else:
     typeof = jax.core.get_aval  # pyright: ignore[reportAttributeAccessIssue]
 
 
-# `AbstractValue.to_ct_aval` (the cotangent aval, used to build `Zero`s for
-# custom_vjp bwd rules -- see `jax._src.custom_derivatives._flatten_bwd`) is
-# not present on the `jax>=0.7.2` floor; only `to_tangent_aval` is. For every
-# shaped aval the two coincide (a cotangent lives in the tangent space), so
-# `to_tangent_aval` is a faithful stand-in on old JAX. Probed via `hasattr`
-# rather than a version flag: the exact release that added `to_ct_aval` has
-# not been verified, and a probe stays correct regardless.
+# `AbstractValue.to_ct_aval` is absent on the `jax>=0.7.2` floor, where only
+# `to_tangent_aval` exists; the two coincide for shaped avals. Probed with
+# `hasattr` because the release that added `to_ct_aval` is unverified.
 _HAS_TO_CT_AVAL: Final = hasattr(
     jax.core.ShapedArray,  # pyright: ignore[reportAttributeAccessIssue]
     "to_ct_aval",

--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -12,6 +12,7 @@ __all__ = (
     "jit_p",
     "is_early_inline",
     "scan_bind_params",
+    "to_ct_aval",
     "typeof",
     "unpack_scan_args",
 )
@@ -158,6 +159,24 @@ if JAX_GE_0_8_2:
     typeof = jax.typeof
 else:
     typeof = jax.core.get_aval  # pyright: ignore[reportAttributeAccessIssue]
+
+
+# `AbstractValue.to_ct_aval` (the cotangent aval, used to build `Zero`s for
+# custom_vjp bwd rules -- see `jax._src.custom_derivatives._flatten_bwd`) is
+# not present on the `jax>=0.7.2` floor; only `to_tangent_aval` is. For every
+# shaped aval the two coincide (a cotangent lives in the tangent space), so
+# `to_tangent_aval` is a faithful stand-in on old JAX. Probed via `hasattr`
+# rather than a version flag: the exact release that added `to_ct_aval` has
+# not been verified, and a probe stays correct regardless.
+_HAS_TO_CT_AVAL: Final = hasattr(
+    jax.core.ShapedArray,  # pyright: ignore[reportAttributeAccessIssue]
+    "to_ct_aval",
+)
+
+
+def to_ct_aval(aval: Any, /) -> Any:
+    """Return `aval`'s cotangent aval, on any supported JAX version."""
+    return aval.to_ct_aval() if _HAS_TO_CT_AVAL else aval.to_tangent_aval()
 
 
 # Mark `jax.Array` as "faithful" for `plum` multiple dispatch.

--- a/src/quax/_trace.py
+++ b/src/quax/_trace.py
@@ -13,7 +13,7 @@ import plum
 from jax.custom_derivatives import SymbolicZero as SZ
 from jax.interpreters.ad import Zero
 
-from ._compat import JAX_GE_0_9_2, to_ct_aval, typeof
+from ._compat import JAX_GE_0_9_2, JAX_GE_0_11_0, to_ct_aval, typeof
 from ._dispatch import (
     _default_process,
     _dispatch_cache,
@@ -503,9 +503,17 @@ def _custom_vjp_bwd_wrap(f, tag, in_treedef, in_leaf_avals, fwd_aux, *res_and_ct
             for x in (*res_values, *ct_values)
         ]
         with core.set_current_trace(trace):
+            # JAX 0.11 added `defvjp_with_logs`: the flat bwd rule now returns a
+            # `(cotangents, logs)` pair rather than a bare list of cotangents,
+            # and `ad._custom_lin_transpose` unpacks that pair from us in turn
+            # (`cts_in, logs = bwd.call_wrapped(...)`). `logs` is `None` unless
+            # the rule was registered with `defvjp_with_logs`; pass whatever the
+            # wrapped rule produced straight through.
+            raw = f(*in_tracers)
+            raw, logs = raw if JAX_GE_0_11_0 else (raw, None)
             cts_in = [
                 x if x is None or type(x) in (Zero, SZ) else trace.to_value(x)
-                for x in f(*in_tracers)
+                for x in raw
             ]
         del trace, in_tracers
 
@@ -526,7 +534,8 @@ def _custom_vjp_bwd_wrap(f, tag, in_treedef, in_leaf_avals, fwd_aux, *res_and_ct
                 raise TypeError(msg)
             out.extend(leaves)
         i += n
-    return out
+    # Mirror the shape JAX expects back (see the `defvjp_with_logs` note above).
+    return (out, logs) if JAX_GE_0_11_0 else out
 
 
 # Any -> Any so overloads carry the public types. mypy can't prove the else

--- a/src/quax/_trace.py
+++ b/src/quax/_trace.py
@@ -1,3 +1,4 @@
+import functools as ft
 import itertools as it
 from collections.abc import Sequence
 from typing import Any, overload
@@ -10,6 +11,7 @@ import jax.numpy as jnp
 import jax.tree_util as jtu
 import plum
 from jax.custom_derivatives import SymbolicZero as SZ
+from jax.interpreters.ad import Zero
 
 from ._compat import JAX_GE_0_9_2, typeof
 from ._dispatch import (
@@ -248,6 +250,47 @@ class _QuaxTrace(
             out_values = jtu.tree_unflatten(out_treedef, out_leaves)
             return [_QuaxTracer(self, x) for x in out_values]
 
+    def process_custom_vjp_call(
+        self, primitive, fun, fwd, bwd, tracers, *, out_trees, symbolic_zeros
+    ) -> "list[_QuaxTracer]":
+        # Each `t.value` is a `Value`, and thus a PyTree; flatten the
+        # `Value`-ness away and re-bind the primitive over the leaves.
+        in_values = [self.to_value(t) for t in tracers]
+        in_leaves, in_treedef = jtu.tree_flatten(in_values)
+        in_leaf_avals = tuple(typeof(x) for x in in_leaves)
+
+        fun, fun_aux = _custom_vjp_fun_wrap(fun, self.tag, in_treedef)
+        fwd, fwd_aux = _custom_vjp_fwd_wrap(fwd, self.tag, in_treedef, out_trees)
+        bwd = _custom_vjp_bwd_wrap(bwd, self.tag, in_treedef, in_leaf_avals, fwd_aux)
+
+        def quax_out_trees():
+            # Downstream only reads leaf counts and the forwarding list. Our
+            # `fwd` returns every residual explicitly, so nothing is forwarded.
+            out_treedef, res_treedef = fwd_aux()
+            return out_treedef, res_treedef, [None] * res_treedef.num_leaves
+
+        if JAX_GE_0_9_2:
+            params = dict(
+                subfuns=(fun, fwd, bwd),
+                out_trees=quax_out_trees,
+                symbolic_zeros=symbolic_zeros,
+            )
+            out_leaves = primitive.bind_with_trace(
+                self.parent_trace, tuple(in_leaves), in_leaf_avals, params
+            )
+        else:
+            out_leaves = primitive.bind_with_trace(
+                self.parent_trace,
+                (fun, fwd, bwd, *in_leaves),
+                dict(out_trees=quax_out_trees, symbolic_zeros=symbolic_zeros),
+            )
+
+        # Either the primal or the fwd rule ran, depending on the parent trace.
+        fst, aux = lu.merge_linear_aux(fun_aux, fwd_aux)
+        out_treedef = aux if fst else aux[0]
+        out_values = jtu.tree_unflatten(out_treedef, out_leaves)
+        return [_QuaxTracer(self, x) for x in out_values]
+
     # TODO: add other process_* rules
 
 
@@ -357,6 +400,123 @@ def _custom_jvp_jvp_wrap(tag, in_treedef, *in_primals_and_tangents):
             "Primals and tangents had the same class, but different flattened results."
         )
     yield out_primals + out_tangents, out_primal_treedef
+
+
+def _leaf_counts(treedef: jtu.PyTreeDef, /) -> list[int]:  # pyright: ignore[reportInvalidTypeForm]
+    """Number of leaves contributed by each element of a flattened list."""
+    return [child.num_leaves for child in treedef.children()]
+
+
+@ft.partial(lu.transformation_with_aux2, use_eq_store=True)
+def _custom_vjp_fun_wrap(f, store, tag, in_treedef, *in_leaves):
+    """Run the primal function on re-inflated `Value`s; store the out treedef."""
+    in_values = jtu.tree_unflatten(in_treedef, in_leaves)
+    with core.take_current_trace() as parent_trace:
+        trace = _QuaxTrace(parent_trace, tag)
+        in_tracers = [_QuaxTracer(trace, x) for x in in_values]
+        with core.set_current_trace(trace):
+            out_values = [trace.to_value(t) for t in f(*in_tracers)]
+        del trace, in_tracers
+    out_leaves, out_treedef = jtu.tree_flatten(out_values)
+    store.store(out_treedef)
+    return out_leaves
+
+
+@ft.partial(lu.transformation_with_aux2, use_eq_store=True)
+def _custom_vjp_fwd_wrap(f, store, tag, in_treedef, out_trees, *in_leaves_and_nz):
+    """Run the fwd rule on `Value`s, returning `(*residuals, *primal_outs)` as leaves.
+
+    JAX interleaves each argument with a "this argument has a nonzero tangent"
+    flag. Those flags arrive per *leaf*; the wrapped rule wants one per `Value`,
+    so they are OR-ed together over each value's leaves.
+    """
+    leaves = in_leaves_and_nz[::2]
+    nzs = in_leaves_and_nz[1::2]
+    in_values = jtu.tree_unflatten(in_treedef, leaves)
+
+    value_nzs = []
+    i = 0
+    for n in _leaf_counts(in_treedef):
+        value_nzs.append(any(nzs[i : i + n]))
+        i += n
+
+    with core.take_current_trace() as parent_trace:
+        trace = _QuaxTrace(parent_trace, tag)
+        in_tracers = [_QuaxTracer(trace, x) for x in in_values]
+        interleaved = [x for pair in zip(in_tracers, value_nzs) for x in pair]
+        with core.set_current_trace(trace):
+            res_and_primals_out = f(*interleaved)
+            # JAX prunes residuals that are identical to an input, recording the
+            # index in `input_forwards`; splice them back so we can flatten the
+            # full residual list (see `ad.JVPTrace.process_custom_vjp_call`).
+            _, res_tree, input_forwards = out_trees()
+            n_forwarded = sum(idx is not None for idx in input_forwards)
+            n_res_out = res_tree.num_leaves - n_forwarded
+            res_out = iter(res_and_primals_out[:n_res_out])
+            res = [
+                next(res_out) if idx is None else in_tracers[idx]
+                for idx in input_forwards
+            ]
+            res_values = [trace.to_value(t) for t in res]
+            out_values = [trace.to_value(t) for t in res_and_primals_out[n_res_out:]]
+        del trace, in_tracers
+
+    res_leaves, res_treedef = jtu.tree_flatten(res_values)
+    out_leaves, out_treedef = jtu.tree_flatten(out_values)
+    store.store((out_treedef, res_treedef))
+    return [*res_leaves, *out_leaves]
+
+
+@lu.transformation2
+def _custom_vjp_bwd_wrap(f, tag, in_treedef, in_leaf_avals, fwd_aux, *res_and_cts):
+    """Run the bwd rule on `Value`s, returning one cotangent per input *leaf*."""
+    out_treedef, res_treedef = fwd_aux()
+    n_res = res_treedef.num_leaves
+    res_values = jtu.tree_unflatten(res_treedef, res_and_cts[:n_res])
+    ct_values = jtu.tree_unflatten(out_treedef, res_and_cts[n_res:])
+    # With `symbolic_zeros=True` JAX hands us SymbolicZero leaves. A `Value`
+    # holding SZ leaves cannot answer `aval()`, so lift a fully-symbolic
+    # cotangent back to a value-level SZ, matching `_custom_jvp_jvp_wrap`.
+    ct_values = [
+        SZ(leaves[0].aval)
+        if (leaves := jtu.tree_leaves(c, is_leaf=lambda x: type(x) is SZ))
+        and all(type(x) is SZ for x in leaves)
+        and len(leaves) == 1
+        else c
+        for c in ct_values
+    ]
+
+    with core.take_current_trace() as parent_trace:
+        trace = _QuaxTrace(parent_trace, tag)
+        in_tracers = [
+            x if type(x) is SZ else _QuaxTracer(trace, x)  # pyright: ignore[reportArgumentType]
+            for x in (*res_values, *ct_values)
+        ]
+        with core.set_current_trace(trace):
+            cts_in = [
+                x if x is None or type(x) in (Zero, SZ) else trace.to_value(x)
+                for x in f(*in_tracers)
+            ]
+        del trace, in_tracers
+
+    out: list[Any] = []
+    i = 0
+    for n, ct in zip(_leaf_counts(in_treedef), cts_in, strict=True):
+        avals = in_leaf_avals[i : i + n]
+        if ct is None or type(ct) in (Zero, SZ):
+            out.extend(Zero(a.to_ct_aval()) for a in avals)
+        else:
+            leaves = jtu.tree_leaves(ct)
+            if len(leaves) != n:
+                msg = (
+                    "custom_vjp bwd rule returned a cotangent that flattens to "
+                    f"{len(leaves)} leaves for an input that flattens to {n}. "
+                    "The cotangent must have the same structure as the primal."
+                )
+                raise TypeError(msg)
+            out.extend(leaves)
+        i += n
+    return out
 
 
 # Any -> Any so overloads carry the public types. mypy can't prove the else

--- a/src/quax/_trace.py
+++ b/src/quax/_trace.py
@@ -13,7 +13,7 @@ import plum
 from jax.custom_derivatives import SymbolicZero as SZ
 from jax.interpreters.ad import Zero
 
-from ._compat import JAX_GE_0_9_2, typeof
+from ._compat import JAX_GE_0_9_2, to_ct_aval, typeof
 from ._dispatch import (
     _default_process,
     _dispatch_cache,
@@ -504,7 +504,7 @@ def _custom_vjp_bwd_wrap(f, tag, in_treedef, in_leaf_avals, fwd_aux, *res_and_ct
     for n, ct in zip(_leaf_counts(in_treedef), cts_in, strict=True):
         avals = in_leaf_avals[i : i + n]
         if ct is None or type(ct) in (Zero, SZ):
-            out.extend(Zero(a.to_ct_aval()) for a in avals)
+            out.extend(Zero(to_ct_aval(a)) for a in avals)
         else:
             leaves = jtu.tree_leaves(ct)
             if len(leaves) != n:

--- a/src/quax/_trace.py
+++ b/src/quax/_trace.py
@@ -475,9 +475,19 @@ def _custom_vjp_bwd_wrap(f, tag, in_treedef, in_leaf_avals, fwd_aux, *res_and_ct
     res_values = jtu.tree_unflatten(res_treedef, res_and_cts[:n_res])
     ct_values = jtu.tree_unflatten(out_treedef, res_and_cts[n_res:])
     # With `symbolic_zeros=True` JAX hands us SymbolicZero leaves. A `Value`
-    # holding SZ leaves cannot answer `aval()`, so lift a fully-symbolic
-    # cotangent back to a value-level SZ, matching `_custom_jvp_jvp_wrap`.
+    # holding SZ leaves cannot answer `aval()`, so when a cotangent flattens
+    # to exactly one leaf and that leaf is an SZ, lift it back to a
+    # value-level SZ, matching `_custom_jvp_jvp_wrap`. `all(...)` is what
+    # confirms the one leaf actually *is* an SZ (not just that there's one
+    # of them) -- dropping it would wrongly promote every single-leaf
+    # cotangent, symbolic or not. A multi-leaf `Value` whose cotangent is
+    # fully symbolic isn't handled here and falls through with its SZ leaves
+    # embedded (see plan follow-up item 2).
     ct_values = [
+        # Uses the *leaf's* aval, unlike `_custom_jvp_jvp_wrap`'s
+        # `SZ(type(p).aval(p))` (the *Value*'s aval) -- assumes they agree
+        # for any single-leaf `Value`. No current example type violates
+        # that; if one did, its bwd rule would see a wrongly-shaped SZ.
         SZ(leaves[0].aval)
         if (leaves := jtu.tree_leaves(c, is_leaf=lambda x: type(x) is SZ))
         and all(type(x) is SZ for x in leaves)

--- a/src/quax/_trace.py
+++ b/src/quax/_trace.py
@@ -474,20 +474,12 @@ def _custom_vjp_bwd_wrap(f, tag, in_treedef, in_leaf_avals, fwd_aux, *res_and_ct
     n_res = res_treedef.num_leaves
     res_values = jtu.tree_unflatten(res_treedef, res_and_cts[:n_res])
     ct_values = jtu.tree_unflatten(out_treedef, res_and_cts[n_res:])
-    # With `symbolic_zeros=True` JAX hands us SymbolicZero leaves. A `Value`
-    # holding SZ leaves cannot answer `aval()`, so when a cotangent flattens
-    # to exactly one leaf and that leaf is an SZ, lift it back to a
-    # value-level SZ, matching `_custom_jvp_jvp_wrap`. `all(...)` is what
-    # confirms the one leaf actually *is* an SZ (not just that there's one
-    # of them) -- dropping it would wrongly promote every single-leaf
-    # cotangent, symbolic or not. A multi-leaf `Value` whose cotangent is
-    # fully symbolic isn't handled here and falls through with its SZ leaves
-    # embedded (see plan follow-up item 2).
+    # A `Value` holding SZ leaves cannot answer `aval()`, so lift a single-leaf
+    # symbolic cotangent back to a value-level SZ (`all(...)` checks the leaf
+    # *is* an SZ). Multi-leaf symbolic cotangents fall through unhandled.
     ct_values = [
-        # Uses the *leaf's* aval, unlike `_custom_jvp_jvp_wrap`'s
-        # `SZ(type(p).aval(p))` (the *Value*'s aval) -- assumes they agree
-        # for any single-leaf `Value`. No current example type violates
-        # that; if one did, its bwd rule would see a wrongly-shaped SZ.
+        # The leaf's aval, not the `Value`'s (`_custom_jvp_jvp_wrap` uses the
+        # latter); they agree for every single-leaf `Value` we know of.
         SZ(leaves[0].aval)
         if (leaves := jtu.tree_leaves(c, is_leaf=lambda x: type(x) is SZ))
         and all(type(x) is SZ for x in leaves)
@@ -503,12 +495,8 @@ def _custom_vjp_bwd_wrap(f, tag, in_treedef, in_leaf_avals, fwd_aux, *res_and_ct
             for x in (*res_values, *ct_values)
         ]
         with core.set_current_trace(trace):
-            # JAX 0.11 added `defvjp_with_logs`: the flat bwd rule now returns a
-            # `(cotangents, logs)` pair rather than a bare list of cotangents,
-            # and `ad._custom_lin_transpose` unpacks that pair from us in turn
-            # (`cts_in, logs = bwd.call_wrapped(...)`). `logs` is `None` unless
-            # the rule was registered with `defvjp_with_logs`; pass whatever the
-            # wrapped rule produced straight through.
+            # JAX 0.11's `defvjp_with_logs` made the flat bwd rule return a
+            # `(cotangents, logs)` pair, which our caller unpacks in turn.
             raw = f(*in_tracers)
             raw, logs = raw if JAX_GE_0_11_0 else (raw, None)
             cts_in = [
@@ -534,7 +522,6 @@ def _custom_vjp_bwd_wrap(f, tag, in_treedef, in_leaf_avals, fwd_aux, *res_and_ct
                 raise TypeError(msg)
             out.extend(leaves)
         i += n
-    # Mirror the shape JAX expects back (see the `defvjp_with_logs` note above).
     return (out, logs) if JAX_GE_0_11_0 else out
 
 

--- a/src/quax/examples/unitful/_core.py
+++ b/src/quax/examples/unitful/_core.py
@@ -43,7 +43,7 @@ class Unitful(quax.ArrayValue):
 
 
 @quax.register(jax.lax.add_p)
-def _(x: Unitful, y: Unitful):  # function name doesn't matter
+def add_unitful_unitful(x: Unitful, y: Unitful):
     if x.units == y.units:
         return Unitful(x.array + y.array, x.units)
     else:
@@ -51,7 +51,7 @@ def _(x: Unitful, y: Unitful):  # function name doesn't matter
 
 
 @quax.register(jax.lax.mul_p)
-def _(x: Unitful, y: Unitful, /, **kw: Any) -> Unitful:
+def mul_unitful_unitful(x: Unitful, y: Unitful, /, **kw: Any) -> Unitful:
     units = x.units.copy()
     for k, v in y.units.items():
         if k in units:
@@ -62,23 +62,23 @@ def _(x: Unitful, y: Unitful, /, **kw: Any) -> Unitful:
 
 
 @quax.register(jax.lax.mul_p)
-def _(x: ArrayLike, y: Unitful, /, **kw: Any) -> Unitful:
+def mul_arraylike_unitful(x: ArrayLike, y: Unitful, /, **kw: Any) -> Unitful:
     return Unitful(jax.lax.mul_p.bind(x, y.array, **kw), y.units)
 
 
 @quax.register(jax.lax.mul_p)
-def _(x: Unitful, y: ArrayLike, /, **kw: Any) -> Unitful:
+def mul_unitful_arraylike(x: Unitful, y: ArrayLike, /, **kw: Any) -> Unitful:
     return Unitful(jax.lax.mul_p.bind(x.array, y, **kw), x.units)
 
 
 @quax.register(jax.lax.integer_pow_p)
-def _(x: Unitful, *, y: int):
+def integer_pow_unitful(x: Unitful, *, y: int):
     units = {k: v * y for k, v in x.units.items()}
     return Unitful(jax.lax.integer_pow_p.bind(x.array, y=y), units)
 
 
 @quax.register(jax.lax.lt_p)
-def _(x: Unitful, y: Unitful, **kwargs):
+def lt_unitful_unitful(x: Unitful, y: Unitful, **kwargs):
     if x.units == y.units:
         return jax.lax.lt(x.array, y.array, **kwargs)
     else:
@@ -88,19 +88,19 @@ def _(x: Unitful, y: Unitful, **kwargs):
 
 
 @quax.register(jax.lax.broadcast_in_dim_p)
-def _(operand: Unitful, **kwargs):
+def broadcast_in_dim_unitful(operand: Unitful, **kwargs):
     kwargs.pop("sharding", None)  # TODO: handle sharding
     new_arr = jax.lax.broadcast_in_dim(operand.array, **kwargs)
     return Unitful(new_arr, operand.units)
 
 
 @quax.register(jax.lax.copy_p)
-def _(x: Unitful, **kw: Any) -> Unitful:
+def copy_unitful(x: Unitful, **kw: Any) -> Unitful:
     return Unitful(jax.lax.copy_p.bind(x.array, **kw), x.units)
 
 
 @quax.register(jax.lax.select_n_p)
-def _(which: ArrayLike, *cases: Unitful, **kw: Any) -> Unitful:
+def select_n_unitful(which: ArrayLike, *cases: Unitful, **kw: Any) -> Unitful:
     units = cases[0].units
     if any(c.units != units for c in cases[1:]):
         raise ValueError(

--- a/src/quax/examples/unitful/_core.py
+++ b/src/quax/examples/unitful/_core.py
@@ -92,3 +92,19 @@ def _(operand: Unitful, **kwargs):
     kwargs.pop("sharding", None)  # TODO: handle sharding
     new_arr = jax.lax.broadcast_in_dim(operand.array, **kwargs)
     return Unitful(new_arr, operand.units)
+
+
+@quax.register(jax.lax.copy_p)
+def _(x: Unitful, **kw: Any) -> Unitful:
+    return Unitful(jax.lax.copy_p.bind(x.array, **kw), x.units)
+
+
+@quax.register(jax.lax.select_n_p)
+def _(which: ArrayLike, *cases: Unitful, **kw: Any) -> Unitful:
+    units = cases[0].units
+    if any(c.units != units for c in cases[1:]):
+        raise ValueError(
+            f"Cannot select between arrays with units {[c.units for c in cases]}."
+        )
+    arrays = [c.array for c in cases]
+    return Unitful(jax.lax.select_n_p.bind(which, *arrays, **kw), units)

--- a/src/quax/examples/unitful/_core.py
+++ b/src/quax/examples/unitful/_core.py
@@ -62,12 +62,12 @@ def mul_unitful_unitful(x: Unitful, y: Unitful, /, **kw: Any) -> Unitful:
 
 
 @quax.register(jax.lax.mul_p)
-def mul_arraylike_unitful(x: ArrayLike, y: Unitful, /, **kw: Any) -> Unitful:
+def mul_array_like_unitful(x: ArrayLike, y: Unitful, /, **kw: Any) -> Unitful:
     return Unitful(jax.lax.mul_p.bind(x, y.array, **kw), y.units)
 
 
 @quax.register(jax.lax.mul_p)
-def mul_unitful_arraylike(x: Unitful, y: ArrayLike, /, **kw: Any) -> Unitful:
+def mul_unitful_array_like(x: Unitful, y: ArrayLike, /, **kw: Any) -> Unitful:
     return Unitful(jax.lax.mul_p.bind(x.array, y, **kw), x.units)
 
 

--- a/tests/benchmark/test_autodiff.py
+++ b/tests/benchmark/test_autodiff.py
@@ -1,13 +1,17 @@
 """Benchmarks for the autodiff path through a quax trace.
 
-``_QuaxTrace.process_custom_jvp_call`` and its two ``lu.transformation_with_aux``
-wrappers (``_custom_jvp_fun_wrap`` / ``_custom_jvp_jvp_wrap``) are the only
-``process_*`` override besides ``process_primitive``, and had no benchmark
-coverage at all. They do noticeably more per call than plain dispatch --
+``_QuaxTrace.process_custom_jvp_call`` and ``process_custom_vjp_call``, with
+their ``lu.transformation`` wrappers, are the ``process_*`` overrides besides
+``process_primitive``. They do noticeably more per call than plain dispatch --
 flatten/unflatten of every `Value` through a treedef, the `SymbolicZero`
-promotion scan over the tangents, and the primal/tangent `materialise` fallback
-when the two come back as different classes -- so a regression there is invisible
-to the ``test_dispatch`` benchmarks.
+promotion scan, and the primal/tangent `materialise` fallback when the two come
+back as different classes -- so a regression there is invisible to the
+``test_dispatch`` benchmarks.
+
+The vjp side adds a third wrapper: ``_custom_vjp_fwd_wrap`` re-splices residuals
+that JAX pruned as forwarded inputs, and ``_custom_vjp_bwd_wrap`` expands each
+cotangent back to one entry per input *leaf*. Both are per-call work that only
+the grad benchmark reaches.
 
 `test_lora_mlp_grad` is the end-to-end version: `filter_grad` over a loraified
 MLP under `jax.jit`, i.e. the workload quax's flagship example actually exists
@@ -57,6 +61,41 @@ def test_custom_jvp_grad(benchmark):
     `_custom_jvp_jvp_wrap`: the tangent `SymbolicZero` scan and the
     primal/tangent class reconciliation."""
     qfn = quax.quaxify(eqx.filter_grad(lambda a: jnp.sum(_custom_jvp_fn(a))))
+    qfn(_xm)
+    benchmark(lambda: qfn(_xm))
+
+
+@jax.custom_vjp
+def _custom_vjp_fn(x):
+    return jnp.sin(x)
+
+
+def _custom_vjp_fn_fwd(x):
+    return jnp.sin(x), jnp.cos(x)
+
+
+def _custom_vjp_fn_bwd(res, ct):
+    return (res * ct,)
+
+
+_custom_vjp_fn.defvjp(_custom_vjp_fn_fwd, _custom_vjp_fn_bwd)
+
+
+@pytest.mark.benchmark(group="autodiff")
+def test_custom_vjp_forward(benchmark):
+    """`quaxify` over a `custom_vjp` function — `process_custom_vjp_call` +
+    `_custom_vjp_fun_wrap` (forward only; fwd/bwd are never entered)."""
+    qfn = quax.quaxify(_custom_vjp_fn)
+    qfn(_xm)  # warm the dispatch cache
+    benchmark(lambda: qfn(_xm))
+
+
+@pytest.mark.benchmark(group="autodiff")
+def test_custom_vjp_grad(benchmark):
+    """`quaxify(grad(custom_vjp fn))` — additionally exercises
+    `_custom_vjp_fwd_wrap` (residual re-splicing, the substituted `out_trees`
+    thunk) and `_custom_vjp_bwd_wrap` (per-leaf cotangent expansion)."""
+    qfn = quax.quaxify(eqx.filter_grad(lambda a: jnp.sum(_custom_vjp_fn(a))))
     qfn(_xm)
     benchmark(lambda: qfn(_xm))
 

--- a/tests/integration/test_diffrax_unitful.py
+++ b/tests/integration/test_diffrax_unitful.py
@@ -10,17 +10,30 @@ and `cond_quax` then rejects the branch whose other side carries a `Value`.
 Driving `solver.step` directly avoids that buffer while keeping the numerics.
 
 This module only covers the forward direction (unit propagation through
-`quaxify`). It does *not* attempt reverse-mode AD: quax's `custom_vjp`
-support does not round-trip equinox's `filter_custom_vjp` perturbation
-metadata, so a flag equinox expects to be a static Python `bool` arrives
-traced, and `jax.grad` through this call raises `TracerBoolConversionError`
-inside equinox itself, at `equinox/internal/_loop/checkpointed.py:766`
-(reached via `_checkpointed_while_loop_bwd`). This reproduces with a bare
-`eqxi.while_loop(kind="checkpointed")` under `quaxify` -- no diffrax and no
-`Unitful` required -- and is not a regression: ordinary `custom_vjp`
-reverse-mode already works (see `tests/unit/test_custom_vjp.py`); this gap
-is specific to `filter_custom_vjp`. See task-5-report.md's fix-round-2
-section for the full writeup.
+`quaxify`). It does *not* attempt reverse-mode AD, for two independent
+reasons, layered:
+
+1. For `Unitful` specifically (the state type this module uses), `jax.grad`
+   fails *first* at a `select_n` dispatch over mixed plain/`Unitful`
+   operands: a value read back out of one of equinox's pre-allocated
+   buffers arrives as a plain array with no rule against the `Value` it
+   meets, and `Unitful.materialise` refuses to paper over that. This is the
+   same buffer-erasure limitation already documented in this module's
+   `add_p` comment block below.
+2. Behind that: even with a fully materialisable dense `quax.ArrayValue` and
+   *no* bridging rules at all, `jax.grad` still fails, with
+   `TracerBoolConversionError` inside equinox itself, at
+   `equinox/internal/_loop/checkpointed.py:766` (reached via
+   `_checkpointed_while_loop_bwd`; no quax frame appears in the raising
+   line). So fixing (1) alone would not make reverse-mode work here -- a
+   `Value` is required to reproduce either level (plain arrays make
+   `quaxify` short-circuit before installing its trace, so a plain-array
+   run of the same loop proves nothing).
+
+Neither gap is a regression: ordinary `custom_vjp` reverse-mode already
+works (see `tests/unit/test_custom_vjp.py`). See task-5-report.md's
+fix-round-3 section for the full A/B/C configuration matrix (hit counts and
+innermost frames) this account is drawn from.
 """
 
 from typing import Any
@@ -84,8 +97,13 @@ diffrax = pytest.importorskip("diffrax")
 # only -- the notebook and `tests/usage/test_unitful.py` never run in that
 # process -- and every other CI job never installs diffrax, so this module is
 # never imported there either. The only place the two can collide is a local
-# `uv run --group test-integration pytest tests -q`, a deliberate, explicit
-# invocation -- not something that can happen by accident in CI.
+# environment that has diffrax installed and runs a `pytest` invocation
+# covering both this directory and `tests/usage/`/the notebook in the same
+# process -- e.g. `uv run --group test-integration pytest tests -q`, or even
+# a bare `pytest` (`testpaths` already includes `tests`, so `tests/
+# integration` is collected as soon as diffrax is importable, group or no
+# group). Either way it's a deliberate, explicit local invocation -- not
+# something that can happen by accident in CI.
 # ---------------------------------------------------------------------------
 
 
@@ -176,15 +194,19 @@ def test_diffrax_step_exercises_custom_vjp():
     assert calls > 0
 
 
-# No `test_diffrax_step_grad` here. quax's `custom_vjp` support does not
-# round-trip equinox's `filter_custom_vjp` perturbation metadata: a flag
-# equinox expects to be a static Python `bool` arrives traced, and
-# `jax.grad` through this call raises `TracerBoolConversionError` inside
-# equinox itself, at `equinox/internal/_loop/checkpointed.py:766` (reached
-# via `_checkpointed_while_loop_bwd`) -- no quax frame appears in the
-# failing path. It reproduces with a bare `eqxi.while_loop(kind=
-# "checkpointed")` under `quaxify`, no diffrax or `Unitful` required, and
-# is not a regression (ordinary `custom_vjp` reverse-mode already works,
-# see `tests/unit/test_custom_vjp.py`). Landing this forward-only and
-# documenting the gap is the maintainer-approved plan -- not something to
-# paper over with `xfail`. See task-5-report.md's fix-round-2 section.
+# No `test_diffrax_step_grad` here. `jax.grad` on the exact call this test
+# would have made fails first at the `Unitful` buffer-erasure limitation
+# (see the `add_p` comment block above): a value read back out of one of
+# equinox's pre-allocated buffers meets a `Value` with no rule for the
+# mismatch, and `Unitful.materialise` refuses. That's not the whole story,
+# though -- swap in a fully materialisable dense `quax.ArrayValue` with no
+# bridging rules at all, and `jax.grad` on the *same* bare
+# `eqxi.while_loop(kind="checkpointed")` still fails, with
+# `TracerBoolConversionError` inside equinox itself at
+# `equinox/internal/_loop/checkpointed.py:766` (no quax frame in the
+# raising line). So fixing the buffer limitation would not, by itself, make
+# this test pass. Neither gap is a regression -- ordinary `custom_vjp`
+# reverse-mode already works, see `tests/unit/test_custom_vjp.py`. Landing
+# this forward-only and documenting both gaps is the maintainer-approved
+# plan, not something to paper over with `xfail`. See task-5-report.md's
+# fix-round-3 section for the full configuration matrix.

--- a/tests/integration/test_diffrax_unitful.py
+++ b/tests/integration/test_diffrax_unitful.py
@@ -10,17 +10,17 @@ and `cond_quax` then rejects the branch whose other side carries a `Value`.
 Driving `solver.step` directly avoids that buffer while keeping the numerics.
 
 This module only covers the forward direction (unit propagation through
-`quaxify`). It does *not* attempt reverse-mode AD: `jax.grad` through this
-same call hits a `TracerBoolConversionError` inside
-`quax._trace._custom_vjp_bwd_wrap`, at the point where it re-enters
-`equinox.internal._loop.checkpointed._checkpointed_while_loop_bwd`. A
-scratch-script experiment with a minimal dense (always-materialisable)
-`quax.ArrayValue` -- with no bridging rules at all -- hits the identical
-failure at the identical location, so this is not a `Unitful`-materialise
-limitation; it points at a defect in `_custom_vjp_bwd_wrap` itself. That is
-this branch's headline feature, so it is not this test module's place to
-paper over it with an `xfail` -- see task-5-report.md's fix-round-1 section
-for the full experiment and a BLOCKED finding for a maintainer decision.
+`quaxify`). It does *not* attempt reverse-mode AD: quax's `custom_vjp`
+support does not round-trip equinox's `filter_custom_vjp` perturbation
+metadata, so a flag equinox expects to be a static Python `bool` arrives
+traced, and `jax.grad` through this call raises `TracerBoolConversionError`
+inside equinox itself, at `equinox/internal/_loop/checkpointed.py:766`
+(reached via `_checkpointed_while_loop_bwd`). This reproduces with a bare
+`eqxi.while_loop(kind="checkpointed")` under `quaxify` -- no diffrax and no
+`Unitful` required -- and is not a regression: ordinary `custom_vjp`
+reverse-mode already works (see `tests/unit/test_custom_vjp.py`); this gap
+is specific to `filter_custom_vjp`. See task-5-report.md's fix-round-2
+section for the full writeup.
 """
 
 from typing import Any
@@ -176,11 +176,15 @@ def test_diffrax_step_exercises_custom_vjp():
     assert calls > 0
 
 
-# No `test_diffrax_step_grad` here. `jax.grad` through the quaxified call
-# hits `TracerBoolConversionError` inside `quax._trace._custom_vjp_bwd_wrap`
-# (at its re-entry into
-# `equinox.internal._loop.checkpointed._checkpointed_while_loop_bwd`), and a
-# minimal dense `quax.ArrayValue` with zero bridging rules hits the same
-# error at the same location -- so this is a `_custom_vjp_bwd_wrap` defect,
-# not a `Unitful`-materialise limitation, and not something this test module
-# can paper over with `xfail`. See task-5-report.md's fix-round-1 section.
+# No `test_diffrax_step_grad` here. quax's `custom_vjp` support does not
+# round-trip equinox's `filter_custom_vjp` perturbation metadata: a flag
+# equinox expects to be a static Python `bool` arrives traced, and
+# `jax.grad` through this call raises `TracerBoolConversionError` inside
+# equinox itself, at `equinox/internal/_loop/checkpointed.py:766` (reached
+# via `_checkpointed_while_loop_bwd`) -- no quax frame appears in the
+# failing path. It reproduces with a bare `eqxi.while_loop(kind=
+# "checkpointed")` under `quaxify`, no diffrax or `Unitful` required, and
+# is not a regression (ordinary `custom_vjp` reverse-mode already works,
+# see `tests/unit/test_custom_vjp.py`). Landing this forward-only and
+# documenting the gap is the maintainer-approved plan -- not something to
+# paper over with `xfail`. See task-5-report.md's fix-round-2 section.

--- a/tests/integration/test_diffrax_unitful.py
+++ b/tests/integration/test_diffrax_unitful.py
@@ -1,56 +1,21 @@
 """Unit propagation through a `diffrax` Runge-Kutta solver.
 
 `diffrax` steps its explicit RK stages inside `equinox.internal`'s buffered
-loop, which is implemented with `jax.custom_vjp` -- so this exercises
+loop, which is built on `jax.custom_vjp` -- so this exercises
 `quax._trace._QuaxTrace.process_custom_vjp_call`.
 
-`diffrax.diffeqsolve` itself is *not* used: it allocates its `SaveAt` output
-buffer with `jnp.full`, which Quax never sees, so the buffer is a plain array
-and `cond_quax` then rejects the branch whose other side carries a `Value`.
-Driving `solver.step` directly avoids that buffer while keeping the numerics.
+`diffrax.diffeqsolve` is not used: it allocates its `SaveAt` buffer with
+`jnp.full`, which Quax never sees, so a later `lax.cond` puts a plain buffer
+slice opposite a `Value` and `cond_quax` rejects it. Driving `solver.step`
+keeps the numerics without the buffer.
 
-This module only covers the forward direction (unit propagation through
-`quaxify`). It does *not* attempt reverse-mode AD, for two independent
-reasons, layered:
-
-1. For `Unitful` specifically (the state type this module uses), `jax.grad`
-   fails *first* at a `select_n` dispatch over mixed plain/`Unitful`
-   operands: a value read back out of one of equinox's pre-allocated
-   buffers arrives as a plain array with no rule against the `Value` it
-   meets, and `Unitful.materialise` refuses to paper over that. This is the
-   same buffer-erasure limitation already documented in this module's
-   `add_p` comment block below.
-2. Behind that: even with a fully materialisable dense `quax.ArrayValue` and
-   *no* bridging rules at all, `jax.grad` still fails, with
-   `TracerBoolConversionError` inside equinox itself, at
-   `equinox/internal/_loop/checkpointed.py:766` (reached via
-   `_checkpointed_while_loop_bwd`; no quax frame appears in the raising
-   line). So fixing (1) alone would not make reverse-mode work here -- a
-   `Value` is required to reproduce either level (plain arrays make
-   `quaxify` short-circuit before installing its trace, so a plain-array
-   run of the same loop proves nothing).
-
-Neither gap is a regression: ordinary `custom_vjp` reverse-mode already
-works (see `tests/unit/test_custom_vjp.py`).
-
-That account comes from three configurations, each run with a counting
-monkeypatch on `_QuaxTrace.process_custom_vjp_call` and the innermost frame
-read off the traceback:
-
-- bare `eqxi.while_loop(kind="checkpointed")` over plain arrays (not a
-  `Value`), `jax.grad` -> succeeds, **0** dispatches. `quaxify`
-  short-circuits and never installs its trace when no `Value` is present,
-  so this configuration exercises none of the code above. Recorded so that
-  nobody re-runs it, sees green, and concludes the gap is fixed.
-- the same loop over a minimal materialising dense `ArrayValue`, no
-  bridging rules, `jax.grad` -> `TracerBoolConversionError`, **1**
-  dispatch, innermost frame `equinox/internal/_loop/checkpointed.py:766`.
-  This is gap (2), and it needs no `Unitful` and no diffrax to reproduce.
-- this module's own call (`Unitful` plus the bridging rules below),
-  `jax.grad` -> `ValueError: Refusing to materialise Unitful array.`,
-  **1** dispatch, innermost frame `quax/examples/unitful/_core.py:42`,
-  last primitive dispatched `select_n`. This is gap (1); it never reaches
-  equinox at all, which is why it masks gap (2).
+Forward direction only. `jax.grad` is blocked twice over: for `Unitful` it
+fails first at a `select_n` over mixed plain/`Unitful` operands (the same
+buffer erasure the `add_p` rules below work around), and behind that, even a
+freely-materialising `ArrayValue` hits `TracerBoolConversionError` inside
+equinox at `_loop/checkpointed.py:766`. Fixing the first would not fix the
+second. Ordinary `custom_vjp` reverse-mode is unaffected; see
+`tests/unit/test_custom_vjp.py`.
 """
 
 from typing import Any
@@ -70,58 +35,25 @@ from quax.examples.unitful import meters, Unitful
 diffrax = pytest.importorskip("diffrax")
 
 
-# ---------------------------------------------------------------------------
 # Bridging rules for equinox's scratch buffers.
 #
 # `equinox.internal`'s loops pre-allocate their stage buffers with `jnp.zeros`,
-# which carries no `Unitful` operand for Quax to dispatch on. A quantity
-# written into such a buffer therefore comes back out dimensionless, and the
-# arithmetic that consumes it mixes a plain array with a `Unitful`.
+# so a `Unitful` written into one comes back out dimensionless and then meets a
+# `Unitful` in the arithmetic that consumes it. These rules reattach the
+# `Unitful` operand's units at that boundary.
 #
-# These rules re-attribute the `Unitful` operand's units at that boundary. They
-# are deliberately *not* in `quax.examples.unitful`: "a plain array may be added
-# to a quantity" is unsound as a general units rule, and is only defensible here
-# because the plain operand provably originated as a `Unitful` (or as the
-# literal `0` that diffrax substitutes when zeroing an unused FSAL stage).
+# They are deliberately not in `quax.examples.unitful`: "a plain array may be
+# added to a quantity" is unsound in general, and is only defensible here
+# because the plain operand provably came out of a buffer a `Unitful` went
+# into. The units it had going in are not recoverable at this call site, so
+# these rules trust the `Unitful` operand rather than checking it -- which is
+# why this module tests unit *propagation* and not unit *rejection*.
 #
-# That provenance argument justifies *reusing the value* -- it says nothing
-# about what units to reattach, and there is no honest way to recover that
-# here: `_step_n`'s while-loop body is traced once (by
-# `quax._primitives.while_quax`) and replayed for every runtime stage, so by
-# the time a buffer-derived plain value reaches this `add` rule, the units it
-# had before going into the buffer are gone, and nothing at this call site
-# names which buffer it came from or what was written there. An earlier
-# version of this module tried to reconstruct those units from bookkeeping
-# maintained by the `maybe_set_p` rule below -- comparing the accumulator's
-# units against whatever was most recently written to *any* buffer -- but
-# that check never actually consulted `y` (the operand whose units were
-# erased), so it could neither reject a mismatch between `y` and *its own*
-# buffer nor avoid false positives from an unrelated one. It only happened to
-# agree with the correct answer for this module's one ODE (`dy = rate * y`,
-# where `k`'s units equal `y`'s units iff `rate` is dimensionless). Given
-# that, this module makes no attempt at a rejection test -- see the comment
-# below `test_diffrax_step_propagates_units` -- and unconditionally trusts the
-# accumulator's units, same as the brief originally specified.
-#
-# Because `quax.register` is a process-global registry, once this module is
-# imported this rule accepts *any* `Unitful + plain array` add, for the rest
-# of the process -- silently invalidating the invariant documented in
-# `docs/examples/custom_rules.ipynb` ("Bad example 2": adding a plain array to
-# a `Unitful` should raise, because no such rule exists). That invalidation is
-# real but bounded: it only occurs once diffrax is installed (this module
-# self-skips via `importorskip` otherwise) and only within a process that also
-# imports this module. CI's `integration` job runs `pytest tests/integration`
-# only -- the notebook and `tests/usage/test_unitful.py` never run in that
-# process -- and every other CI job never installs diffrax, so this module is
-# never imported there either. The only place the two can collide is a local
-# environment that has diffrax installed and runs a `pytest` invocation
-# covering both this directory and `tests/usage/`/the notebook in the same
-# process -- e.g. `uv run --group test-integration pytest tests -q`, or even
-# a bare `pytest` (`testpaths` already includes `tests`, so `tests/
-# integration` is collected as soon as diffrax is importable, group or no
-# group). Either way it's a deliberate, explicit local invocation -- not
-# something that can happen by accident in CI.
-# ---------------------------------------------------------------------------
+# `quax.register` is process-global, so once this module is imported the
+# `add_p` rule accepts any `Unitful + plain` add, invalidating the invariant
+# in `docs/examples/custom_rules.ipynb` ("Bad example 2"). CI never hits that:
+# the integration job runs `tests/integration` alone and no other job installs
+# diffrax. A local `pytest` covering both directories at once does.
 
 
 @quax.register(jax.lax.add_p)
@@ -215,19 +147,5 @@ def test_diffrax_step_exercises_custom_vjp():
     assert calls > 0
 
 
-# No `test_diffrax_step_grad` here. `jax.grad` on the exact call this test
-# would have made fails first at the `Unitful` buffer-erasure limitation
-# (see the `add_p` comment block above): a value read back out of one of
-# equinox's pre-allocated buffers meets a `Value` with no rule for the
-# mismatch, and `Unitful.materialise` refuses. That's not the whole story,
-# though -- swap in a fully materialisable dense `quax.ArrayValue` with no
-# bridging rules at all, and `jax.grad` on the *same* bare
-# `eqxi.while_loop(kind="checkpointed")` still fails, with
-# `TracerBoolConversionError` inside equinox itself at
-# `equinox/internal/_loop/checkpointed.py:766` (no quax frame in the
-# raising line). So fixing the buffer limitation would not, by itself, make
-# this test pass. Neither gap is a regression -- ordinary `custom_vjp`
-# reverse-mode already works, see `tests/unit/test_custom_vjp.py`. Landing
-# this forward-only and documenting both gaps is the maintainer-approved
-# plan, not something to paper over with `xfail`. The module docstring
-# records the three configurations this conclusion rests on.
+# No `test_diffrax_step_grad`: reverse-mode does not work here. The module
+# docstring says why, and names both blocking frames.

--- a/tests/integration/test_diffrax_unitful.py
+++ b/tests/integration/test_diffrax_unitful.py
@@ -1,0 +1,193 @@
+"""Unit propagation through a `diffrax` Runge-Kutta solver.
+
+`diffrax` steps its explicit RK stages inside `equinox.internal`'s buffered
+loop, which is implemented with `jax.custom_vjp` -- so this exercises
+`quax._trace._QuaxTrace.process_custom_vjp_call`.
+
+`diffrax.diffeqsolve` itself is *not* used: it allocates its `SaveAt` output
+buffer with `jnp.full`, which Quax never sees, so the buffer is a plain array
+and `cond_quax` then rejects the branch whose other side carries a `Value`.
+Driving `solver.step` directly avoids that buffer while keeping the numerics.
+"""
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import pytest
+from equinox.internal._loop.common import maybe_set_p, select_if_vmap_p
+from jaxtyping import ArrayLike
+
+import quax
+from quax.examples.unitful import meters, seconds, Unitful
+
+
+# `diffrax` lives in the `integration` dependency group, not `tests`, so a
+# default `pytest` run skips this module rather than erroring at collection.
+diffrax = pytest.importorskip("diffrax")
+
+
+# ---------------------------------------------------------------------------
+# Bridging rules for equinox's scratch buffers.
+#
+# `equinox.internal`'s loops pre-allocate their stage buffers with `jnp.zeros`,
+# which carries no `Unitful` operand for Quax to dispatch on. A quantity
+# written into such a buffer therefore comes back out dimensionless, and the
+# arithmetic that consumes it mixes a plain array with a `Unitful`.
+#
+# These rules re-attribute the `Unitful` operand's units at that boundary. They
+# are deliberately *not* in `quax.examples.unitful`: "a plain array may be added
+# to a quantity" is unsound as a general units rule, and is only defensible here
+# because the plain operand provably originated as a `Unitful` (or as the
+# literal `0` that diffrax substitutes when zeroing an unused FSAL stage).
+#
+# That provenance argument only tells us the *value* is safe to reuse -- it
+# says nothing about whether the units silently reattached to it are the
+# *right* units. `_step_n`'s while-loop body is traced exactly once (by
+# `quax._primitives.while_quax`) and then replayed for every runtime stage, so
+# a naive `add` rule that just copies the accumulator's units onto whatever
+# comes out of the buffer can never observe a stage whose computed units
+# differ from the accumulator's -- there is no separate Quax dispatch per
+# dynamic iteration to catch it at. `_buffer_units` closes that gap: the same
+# buffer is written every trace by `maybe_set_p` with the *actual* computed
+# units of a stage (`rate * y`), and `_step_n` calls `solver.step` once per
+# macro-step from ordinary (unquaxified) Python, so those units are available,
+# module-global, by the time the *next* macro-step's `add` rule runs and reads
+# that buffer back. Comparing against them (skipping the very first add, which
+# only ever sees the zero placeholder) is exactly the dimensional check
+# `y + dt * f(t, y)` needs, without requiring per-iteration dispatch.
+# ---------------------------------------------------------------------------
+
+# Units most recently written into equinox's stage buffer, established once
+# per traced while-loop body and reused across the `_step_n` macro-steps that
+# read it back. Reset at the top of `_step_n` so state never leaks between
+# separate calls -- including between separate tests, since `quax.register`
+# is a global registry and these rules run in every test in this session.
+_buffer_units: dict[Any, int] | None = None
+
+
+@quax.register(jax.lax.add_p)
+def _(x: Unitful, y: ArrayLike, **kw: Any) -> Unitful:
+    global _buffer_units
+    if _buffer_units is not None and _buffer_units != x.units:
+        raise ValueError(
+            f"Cannot add two arrays with units {x.units} and {_buffer_units}."
+        )
+    return Unitful(jax.lax.add_p.bind(x.array, y, **kw), x.units)
+
+
+@quax.register(select_if_vmap_p)
+def _(pred: ArrayLike, *cases: Unitful | ArrayLike, **kw: Any) -> Any:
+    unitful = [c.units for c in cases if isinstance(c, Unitful)]
+    if not unitful:
+        return select_if_vmap_p.bind(pred, *cases, **kw)
+    if any(u != unitful[0] for u in unitful[1:]):
+        raise ValueError(f"Cannot select between arrays with units {unitful}.")
+    arrays = [c.array if isinstance(c, Unitful) else c for c in cases]
+    return Unitful(select_if_vmap_p.bind(pred, *arrays, **kw), unitful[0])
+
+
+@quax.register(maybe_set_p)
+def _(pred: ArrayLike, xs: ArrayLike, x: Unitful, *rest: Any, **kw: Any) -> Any:
+    # The buffer `xs` is a plain array; store the magnitude and let the read
+    # side re-attach units via the `add`/`select` rules above. Record the
+    # units actually being written so the *next* macro-step's `add` rule can
+    # check them (see `_buffer_units` above).
+    global _buffer_units
+    _buffer_units = x.units
+    return maybe_set_p.bind(pred, xs, x.array, *rest, **kw)
+
+
+# ---------------------------------------------------------------------------
+# The system: dy/dt = rate * y, with y in metres and `rate` dimensionless
+# (time is carried as plain floats, so `rate` must be per-step, not per-second).
+# ---------------------------------------------------------------------------
+
+N_STEPS = 5
+DT = 0.1
+
+
+def _step_n(y0, rate):
+    global _buffer_units
+    _buffer_units = None  # fresh state per call -- see `_buffer_units` above
+    term = diffrax.ODETerm(lambda t, y, args: args * y)
+    solver = diffrax.Tsit5()
+    state = solver.init(term, 0.0, DT, y0, rate)
+    y = y0
+    for i in range(N_STEPS):
+        y, _, _, state, _ = solver.step(
+            term, i * DT, (i + 1) * DT, y, rate, state, made_jump=False
+        )
+    return y
+
+
+def test_diffrax_step_propagates_units():
+    """Units survive a diffrax RK integration, and the values are unchanged."""
+    y0_val, rate_val = jnp.array([1.0]), jnp.asarray(-0.5)
+    expected = _step_n(y0_val, rate_val)
+
+    got = quax.quaxify(_step_n)(Unitful(y0_val, meters), Unitful(rate_val, {}))
+
+    assert isinstance(got, Unitful)
+    assert got.units == {meters: 1}
+    assert jnp.allclose(got.array, expected)
+
+
+def test_diffrax_step_exercises_custom_vjp():
+    """The integration really does route through `process_custom_vjp_call`."""
+    from quax import _trace
+
+    calls = 0
+    original = _trace._QuaxTrace.process_custom_vjp_call
+
+    def counting(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(self, *args, **kwargs)
+
+    _trace._QuaxTrace.process_custom_vjp_call = counting
+    try:
+        quax.quaxify(_step_n)(
+            Unitful(jnp.array([1.0]), meters), Unitful(jnp.asarray(-0.5), {})
+        )
+    finally:
+        _trace._QuaxTrace.process_custom_vjp_call = original
+
+    assert calls > 0
+
+
+def test_diffrax_step_rejects_inconsistent_units():
+    """A rate with dimensions makes `y + dt * f(t, y)` dimensionally invalid."""
+    with pytest.raises(ValueError, match="Cannot add"):
+        quax.quaxify(_step_n)(
+            Unitful(jnp.array([1.0]), meters),
+            Unitful(jnp.asarray(-0.5), seconds),
+        )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Plain-JAX `jax.grad(_step_n)` succeeds on the same inputs, so this is "
+        "not a diffrax limitation. Under `quaxify`, `custom_vjp`'s fwd rule "
+        "(`_custom_vjp_fwd_wrap` in `quax._trace`) traces "
+        "`_checkpointed_while_loop_fwd`, whose residual-saving path hits a "
+        "`select_n_p` dispatch over a mix of `Unitful` and plain-array cases "
+        "that this module has no bridging rule for; the underlying `ValueError` "
+        "is 'Refusing to materialise Unitful array.'. That fwd/residual path is "
+        "equinox-internal machinery, not something a test-module bridging rule "
+        "can patch -- it is the kind of gap flagged as out of scope in "
+        "task-5-brief.md's follow-up items 2 and 3 (symbolic-zero promotion and "
+        "residual forwarding in `quax._trace`)."
+    ),
+    strict=True,
+)
+def test_diffrax_step_grad():
+    """Reverse-mode AD through the quaxified, unit-carrying integration."""
+    y0_val, rate_val = jnp.array([1.0]), jnp.asarray(-0.5)
+    expected = jax.grad(lambda y: _step_n(y, rate_val).sum())(y0_val)
+
+    got = jax.grad(
+        lambda y: quax.quaxify(_step_n)(y, Unitful(rate_val, {})).array.sum()
+    )(Unitful(y0_val, meters))
+
+    assert jnp.allclose(got.array, expected)

--- a/tests/integration/test_diffrax_unitful.py
+++ b/tests/integration/test_diffrax_unitful.py
@@ -125,12 +125,14 @@ diffrax = pytest.importorskip("diffrax")
 
 
 @quax.register(jax.lax.add_p)
-def _(x: Unitful, y: ArrayLike, **kw: Any) -> Unitful:
+def add_unitful_arraylike(x: Unitful, y: ArrayLike, **kw: Any) -> Unitful:
     return Unitful(jax.lax.add_p.bind(x.array, y, **kw), x.units)
 
 
 @quax.register(select_if_vmap_p)
-def _(pred: ArrayLike, *cases: Unitful | ArrayLike, **kw: Any) -> Any:
+def select_if_vmap_unitful(
+    pred: ArrayLike, *cases: Unitful | ArrayLike, **kw: Any
+) -> Any:
     unitful = [c.units for c in cases if isinstance(c, Unitful)]
     if not unitful:
         return select_if_vmap_p.bind(pred, *cases, **kw)
@@ -141,7 +143,9 @@ def _(pred: ArrayLike, *cases: Unitful | ArrayLike, **kw: Any) -> Any:
 
 
 @quax.register(maybe_set_p)
-def _(pred: ArrayLike, xs: ArrayLike, x: Unitful, *rest: Any, **kw: Any) -> Any:
+def maybe_set_unitful(
+    pred: ArrayLike, xs: ArrayLike, x: Unitful, *rest: Any, **kw: Any
+) -> Any:
     # The buffer `xs` is a plain array; store the magnitude and let the read
     # side re-attach units via the `add`/`select` rules above.
     return maybe_set_p.bind(pred, xs, x.array, *rest, **kw)

--- a/tests/integration/test_diffrax_unitful.py
+++ b/tests/integration/test_diffrax_unitful.py
@@ -57,7 +57,7 @@ diffrax = pytest.importorskip("diffrax")
 
 
 @quax.register(jax.lax.add_p)
-def add_unitful_arraylike(x: Unitful, y: ArrayLike, **kw: Any) -> Unitful:
+def add_unitful_array_like(x: Unitful, y: ArrayLike, **kw: Any) -> Unitful:
     return Unitful(jax.lax.add_p.bind(x.array, y, **kw), x.units)
 
 

--- a/tests/integration/test_diffrax_unitful.py
+++ b/tests/integration/test_diffrax_unitful.py
@@ -31,9 +31,26 @@ reasons, layered:
    run of the same loop proves nothing).
 
 Neither gap is a regression: ordinary `custom_vjp` reverse-mode already
-works (see `tests/unit/test_custom_vjp.py`). See task-5-report.md's
-fix-round-3 section for the full A/B/C configuration matrix (hit counts and
-innermost frames) this account is drawn from.
+works (see `tests/unit/test_custom_vjp.py`).
+
+That account comes from three configurations, each run with a counting
+monkeypatch on `_QuaxTrace.process_custom_vjp_call` and the innermost frame
+read off the traceback:
+
+- bare `eqxi.while_loop(kind="checkpointed")` over plain arrays (not a
+  `Value`), `jax.grad` -> succeeds, **0** dispatches. `quaxify`
+  short-circuits and never installs its trace when no `Value` is present,
+  so this configuration exercises none of the code above. Recorded so that
+  nobody re-runs it, sees green, and concludes the gap is fixed.
+- the same loop over a minimal materialising dense `ArrayValue`, no
+  bridging rules, `jax.grad` -> `TracerBoolConversionError`, **1**
+  dispatch, innermost frame `equinox/internal/_loop/checkpointed.py:766`.
+  This is gap (2), and it needs no `Unitful` and no diffrax to reproduce.
+- this module's own call (`Unitful` plus the bridging rules below),
+  `jax.grad` -> `ValueError: Refusing to materialise Unitful array.`,
+  **1** dispatch, innermost frame `quax/examples/unitful/_core.py:42`,
+  last primitive dispatched `select_n`. This is gap (1); it never reaches
+  equinox at all, which is why it masks gap (2).
 """
 
 from typing import Any
@@ -208,5 +225,5 @@ def test_diffrax_step_exercises_custom_vjp():
 # this test pass. Neither gap is a regression -- ordinary `custom_vjp`
 # reverse-mode already works, see `tests/unit/test_custom_vjp.py`. Landing
 # this forward-only and documenting both gaps is the maintainer-approved
-# plan, not something to paper over with `xfail`. See task-5-report.md's
-# fix-round-3 section for the full configuration matrix.
+# plan, not something to paper over with `xfail`. The module docstring
+# records the three configurations this conclusion rests on.

--- a/tests/integration/test_diffrax_unitful.py
+++ b/tests/integration/test_diffrax_unitful.py
@@ -8,6 +8,19 @@ loop, which is implemented with `jax.custom_vjp` -- so this exercises
 buffer with `jnp.full`, which Quax never sees, so the buffer is a plain array
 and `cond_quax` then rejects the branch whose other side carries a `Value`.
 Driving `solver.step` directly avoids that buffer while keeping the numerics.
+
+This module only covers the forward direction (unit propagation through
+`quaxify`). It does *not* attempt reverse-mode AD: `jax.grad` through this
+same call hits a `TracerBoolConversionError` inside
+`quax._trace._custom_vjp_bwd_wrap`, at the point where it re-enters
+`equinox.internal._loop.checkpointed._checkpointed_while_loop_bwd`. A
+scratch-script experiment with a minimal dense (always-materialisable)
+`quax.ArrayValue` -- with no bridging rules at all -- hits the identical
+failure at the identical location, so this is not a `Unitful`-materialise
+limitation; it points at a defect in `_custom_vjp_bwd_wrap` itself. That is
+this branch's headline feature, so it is not this test module's place to
+paper over it with an `xfail` -- see task-5-report.md's fix-round-1 section
+for the full experiment and a BLOCKED finding for a maintainer decision.
 """
 
 from typing import Any
@@ -19,10 +32,10 @@ from equinox.internal._loop.common import maybe_set_p, select_if_vmap_p
 from jaxtyping import ArrayLike
 
 import quax
-from quax.examples.unitful import meters, seconds, Unitful
+from quax.examples.unitful import meters, Unitful
 
 
-# `diffrax` lives in the `integration` dependency group, not `tests`, so a
+# `diffrax` lives in the `test-integration` dependency group, not `tests`, so a
 # default `pytest` run skips this module rather than erroring at collection.
 diffrax = pytest.importorskip("diffrax")
 
@@ -41,38 +54,43 @@ diffrax = pytest.importorskip("diffrax")
 # because the plain operand provably originated as a `Unitful` (or as the
 # literal `0` that diffrax substitutes when zeroing an unused FSAL stage).
 #
-# That provenance argument only tells us the *value* is safe to reuse -- it
-# says nothing about whether the units silently reattached to it are the
-# *right* units. `_step_n`'s while-loop body is traced exactly once (by
-# `quax._primitives.while_quax`) and then replayed for every runtime stage, so
-# a naive `add` rule that just copies the accumulator's units onto whatever
-# comes out of the buffer can never observe a stage whose computed units
-# differ from the accumulator's -- there is no separate Quax dispatch per
-# dynamic iteration to catch it at. `_buffer_units` closes that gap: the same
-# buffer is written every trace by `maybe_set_p` with the *actual* computed
-# units of a stage (`rate * y`), and `_step_n` calls `solver.step` once per
-# macro-step from ordinary (unquaxified) Python, so those units are available,
-# module-global, by the time the *next* macro-step's `add` rule runs and reads
-# that buffer back. Comparing against them (skipping the very first add, which
-# only ever sees the zero placeholder) is exactly the dimensional check
-# `y + dt * f(t, y)` needs, without requiring per-iteration dispatch.
+# That provenance argument justifies *reusing the value* -- it says nothing
+# about what units to reattach, and there is no honest way to recover that
+# here: `_step_n`'s while-loop body is traced once (by
+# `quax._primitives.while_quax`) and replayed for every runtime stage, so by
+# the time a buffer-derived plain value reaches this `add` rule, the units it
+# had before going into the buffer are gone, and nothing at this call site
+# names which buffer it came from or what was written there. An earlier
+# version of this module tried to reconstruct those units from bookkeeping
+# maintained by the `maybe_set_p` rule below -- comparing the accumulator's
+# units against whatever was most recently written to *any* buffer -- but
+# that check never actually consulted `y` (the operand whose units were
+# erased), so it could neither reject a mismatch between `y` and *its own*
+# buffer nor avoid false positives from an unrelated one. It only happened to
+# agree with the correct answer for this module's one ODE (`dy = rate * y`,
+# where `k`'s units equal `y`'s units iff `rate` is dimensionless). Given
+# that, this module makes no attempt at a rejection test -- see the comment
+# below `test_diffrax_step_propagates_units` -- and unconditionally trusts the
+# accumulator's units, same as the brief originally specified.
+#
+# Because `quax.register` is a process-global registry, once this module is
+# imported this rule accepts *any* `Unitful + plain array` add, for the rest
+# of the process -- silently invalidating the invariant documented in
+# `docs/examples/custom_rules.ipynb` ("Bad example 2": adding a plain array to
+# a `Unitful` should raise, because no such rule exists). That invalidation is
+# real but bounded: it only occurs once diffrax is installed (this module
+# self-skips via `importorskip` otherwise) and only within a process that also
+# imports this module. CI's `integration` job runs `pytest tests/integration`
+# only -- the notebook and `tests/usage/test_unitful.py` never run in that
+# process -- and every other CI job never installs diffrax, so this module is
+# never imported there either. The only place the two can collide is a local
+# `uv run --group test-integration pytest tests -q`, a deliberate, explicit
+# invocation -- not something that can happen by accident in CI.
 # ---------------------------------------------------------------------------
-
-# Units most recently written into equinox's stage buffer, established once
-# per traced while-loop body and reused across the `_step_n` macro-steps that
-# read it back. Reset at the top of `_step_n` so state never leaks between
-# separate calls -- including between separate tests, since `quax.register`
-# is a global registry and these rules run in every test in this session.
-_buffer_units: dict[Any, int] | None = None
 
 
 @quax.register(jax.lax.add_p)
 def _(x: Unitful, y: ArrayLike, **kw: Any) -> Unitful:
-    global _buffer_units
-    if _buffer_units is not None and _buffer_units != x.units:
-        raise ValueError(
-            f"Cannot add two arrays with units {x.units} and {_buffer_units}."
-        )
     return Unitful(jax.lax.add_p.bind(x.array, y, **kw), x.units)
 
 
@@ -90,11 +108,7 @@ def _(pred: ArrayLike, *cases: Unitful | ArrayLike, **kw: Any) -> Any:
 @quax.register(maybe_set_p)
 def _(pred: ArrayLike, xs: ArrayLike, x: Unitful, *rest: Any, **kw: Any) -> Any:
     # The buffer `xs` is a plain array; store the magnitude and let the read
-    # side re-attach units via the `add`/`select` rules above. Record the
-    # units actually being written so the *next* macro-step's `add` rule can
-    # check them (see `_buffer_units` above).
-    global _buffer_units
-    _buffer_units = x.units
+    # side re-attach units via the `add`/`select` rules above.
     return maybe_set_p.bind(pred, xs, x.array, *rest, **kw)
 
 
@@ -108,8 +122,6 @@ DT = 0.1
 
 
 def _step_n(y0, rate):
-    global _buffer_units
-    _buffer_units = None  # fresh state per call -- see `_buffer_units` above
     term = diffrax.ODETerm(lambda t, y, args: args * y)
     solver = diffrax.Tsit5()
     state = solver.init(term, 0.0, DT, y0, rate)
@@ -131,6 +143,14 @@ def test_diffrax_step_propagates_units():
     assert isinstance(got, Unitful)
     assert got.units == {meters: 1}
     assert jnp.allclose(got.array, expected)
+
+
+# No `test_..._rejects_inconsistent_units` here. The `add_p` rule above
+# cannot honestly enforce dimensional consistency -- see the comment block
+# above it -- so this suite asserts unit *propagation* only, not rejection.
+# A real rejection test would need `maybe_set_p` to record units keyed by
+# buffer identity, and `add_p` to consult them only when `y` is provably a
+# read-back of that specific buffer; nothing here establishes that link.
 
 
 def test_diffrax_step_exercises_custom_vjp():
@@ -156,38 +176,11 @@ def test_diffrax_step_exercises_custom_vjp():
     assert calls > 0
 
 
-def test_diffrax_step_rejects_inconsistent_units():
-    """A rate with dimensions makes `y + dt * f(t, y)` dimensionally invalid."""
-    with pytest.raises(ValueError, match="Cannot add"):
-        quax.quaxify(_step_n)(
-            Unitful(jnp.array([1.0]), meters),
-            Unitful(jnp.asarray(-0.5), seconds),
-        )
-
-
-@pytest.mark.xfail(
-    reason=(
-        "Plain-JAX `jax.grad(_step_n)` succeeds on the same inputs, so this is "
-        "not a diffrax limitation. Under `quaxify`, `custom_vjp`'s fwd rule "
-        "(`_custom_vjp_fwd_wrap` in `quax._trace`) traces "
-        "`_checkpointed_while_loop_fwd`, whose residual-saving path hits a "
-        "`select_n_p` dispatch over a mix of `Unitful` and plain-array cases "
-        "that this module has no bridging rule for; the underlying `ValueError` "
-        "is 'Refusing to materialise Unitful array.'. That fwd/residual path is "
-        "equinox-internal machinery, not something a test-module bridging rule "
-        "can patch -- it is the kind of gap flagged as out of scope in "
-        "task-5-brief.md's follow-up items 2 and 3 (symbolic-zero promotion and "
-        "residual forwarding in `quax._trace`)."
-    ),
-    strict=True,
-)
-def test_diffrax_step_grad():
-    """Reverse-mode AD through the quaxified, unit-carrying integration."""
-    y0_val, rate_val = jnp.array([1.0]), jnp.asarray(-0.5)
-    expected = jax.grad(lambda y: _step_n(y, rate_val).sum())(y0_val)
-
-    got = jax.grad(
-        lambda y: quax.quaxify(_step_n)(y, Unitful(rate_val, {})).array.sum()
-    )(Unitful(y0_val, meters))
-
-    assert jnp.allclose(got.array, expected)
+# No `test_diffrax_step_grad` here. `jax.grad` through the quaxified call
+# hits `TracerBoolConversionError` inside `quax._trace._custom_vjp_bwd_wrap`
+# (at its re-entry into
+# `equinox.internal._loop.checkpointed._checkpointed_while_loop_bwd`), and a
+# minimal dense `quax.ArrayValue` with zero bridging rules hits the same
+# error at the same location -- so this is a `_custom_vjp_bwd_wrap` defect,
+# not a `Unitful`-materialise limitation, and not something this test module
+# can paper over with `xfail`. See task-5-report.md's fix-round-1 section.

--- a/tests/unit/test_custom_vjp.py
+++ b/tests/unit/test_custom_vjp.py
@@ -1,0 +1,46 @@
+"""Tests for process_custom_vjp_call."""
+
+import jax
+import jax.numpy as jnp
+
+import quax
+
+from .myarray import MyArray
+
+
+@jax.custom_vjp
+def f_custom_vjp(x: jax.Array) -> jax.Array:
+    return jnp.sin(x)
+
+
+def f_custom_vjp_fwd(x: jax.Array):
+    return jnp.sin(x), jnp.cos(x)
+
+
+def f_custom_vjp_bwd(res, ct):
+    # deliberately scaled by 100 so a test can prove the *custom* rule ran
+    return (100.0 * res * ct,)
+
+
+f_custom_vjp.defvjp(f_custom_vjp_fwd, f_custom_vjp_bwd)
+
+
+def test_custom_vjp_forward():
+    """Forward pass through a quaxified custom_vjp function with MyArray input."""
+    x_val = jnp.arange(1.0, 4.0)
+    expected = f_custom_vjp(x_val)
+
+    got = quax.quaxify(f_custom_vjp)(MyArray(x_val))
+
+    assert isinstance(got, MyArray)
+    assert jnp.allclose(got.array, expected)
+
+
+def test_custom_vjp_grad_uses_custom_rule():
+    """`jax.grad` through a quaxified custom_vjp uses the user's bwd rule."""
+    x_val = jnp.arange(1.0, 4.0)
+
+    got = jax.grad(lambda a: quax.quaxify(f_custom_vjp)(a).array.sum())(MyArray(x_val))
+
+    assert isinstance(got, MyArray)
+    assert jnp.allclose(got.array, 100.0 * jnp.cos(x_val))

--- a/tests/unit/test_custom_vjp.py
+++ b/tests/unit/test_custom_vjp.py
@@ -44,3 +44,148 @@ def test_custom_vjp_grad_uses_custom_rule():
 
     assert isinstance(got, MyArray)
     assert jnp.allclose(got.array, 100.0 * jnp.cos(x_val))
+
+
+@jax.custom_vjp
+def g_custom_vjp(x: jax.Array, y: jax.Array) -> jax.Array:
+    return x * y
+
+
+def g_custom_vjp_fwd(x: jax.Array, y: jax.Array):
+    return x * y, (x, y)
+
+
+def g_custom_vjp_bwd(res, ct):
+    x, y = res
+    return (y * ct, x * ct)
+
+
+g_custom_vjp.defvjp(g_custom_vjp_fwd, g_custom_vjp_bwd)
+
+
+def test_custom_vjp_two_args_forward():
+    """Forward pass with two MyArray arguments."""
+    x_val, y_val = jnp.arange(1.0, 4.0), jnp.arange(2.0, 5.0)
+
+    got = quax.quaxify(g_custom_vjp)(MyArray(x_val), MyArray(y_val))
+
+    assert isinstance(got, MyArray)
+    assert jnp.allclose(got.array, x_val * y_val)
+
+
+def test_custom_vjp_grad_both_argnums():
+    """`jax.grad` w.r.t. both arguments of a two-argument custom_vjp."""
+    x_val, y_val = jnp.arange(1.0, 4.0), jnp.arange(2.0, 5.0)
+
+    got = jax.grad(
+        lambda a, b: quax.quaxify(g_custom_vjp)(a, b).array.sum(), argnums=(0, 1)
+    )(MyArray(x_val), MyArray(y_val))
+
+    assert jnp.allclose(got[0].array, y_val)
+    assert jnp.allclose(got[1].array, x_val)
+
+
+def test_custom_vjp_mixed_value_and_array():
+    """A quaxified custom_vjp accepts a mix of MyArray and plain arrays."""
+    x_val, y_val = jnp.arange(1.0, 4.0), jnp.arange(2.0, 5.0)
+
+    got = quax.quaxify(g_custom_vjp)(MyArray(x_val), y_val)
+
+    assert isinstance(got, MyArray)
+    assert jnp.allclose(got.array, x_val * y_val)
+
+
+def test_custom_vjp_jit_grad():
+    """`jax.jit` around `jax.grad` re-traces the fwd rule without store errors."""
+    x_val = jnp.arange(1.0, 4.0)
+
+    got = jax.jit(jax.grad(lambda a: quax.quaxify(f_custom_vjp)(a).array.sum()))(
+        MyArray(x_val)
+    )
+
+    assert jnp.allclose(got.array, 100.0 * jnp.cos(x_val))
+
+
+def test_custom_vjp_vmap():
+    """`jax.vmap` over a quaxified custom_vjp batches correctly."""
+    xs_val, ys_val = jnp.arange(1.0, 4.0), jnp.arange(2.0, 5.0)
+
+    got = jax.vmap(quax.quaxify(g_custom_vjp))(MyArray(xs_val), MyArray(ys_val))
+
+    assert isinstance(got, MyArray)
+    assert jnp.allclose(got.array, xs_val * ys_val)
+
+
+def test_custom_vjp_vmap_grad():
+    """`jax.vmap` of `jax.grad` through a quaxified custom_vjp."""
+    xs_val, ys_val = jnp.arange(1.0, 4.0), jnp.arange(2.0, 5.0)
+
+    got = jax.vmap(jax.grad(lambda a, b: quax.quaxify(g_custom_vjp)(a, b).array.sum()))(
+        MyArray(xs_val), MyArray(ys_val)
+    )
+
+    assert jnp.allclose(got.array, ys_val)
+
+
+# A custom_vjp declared with `symbolic_zeros=True`: the fwd rule receives
+# `CustomVJPPrimal` wrappers rather than bare values.
+@jax.custom_vjp
+def h_custom_vjp(x: jax.Array, y: jax.Array) -> jax.Array:
+    return x * y
+
+
+def h_custom_vjp_fwd(x, y):
+    return x.value * y.value, (x.value, y.value)
+
+
+def h_custom_vjp_bwd(res, ct):
+    _, y = res
+    return (y * ct, None)  # `None`: no cotangent for `y`
+
+
+h_custom_vjp.defvjp(h_custom_vjp_fwd, h_custom_vjp_bwd, symbolic_zeros=True)
+
+
+def test_custom_vjp_symbolic_zeros():
+    """`symbolic_zeros=True`, including a `None` cotangent for one argument."""
+    x_val, y_val = jnp.arange(1.0, 4.0), jnp.arange(2.0, 5.0)
+
+    got = jax.grad(lambda a, b: quax.quaxify(h_custom_vjp)(a, b).array.sum())(
+        MyArray(x_val), MyArray(y_val)
+    )
+
+    assert jnp.allclose(got.array, y_val)
+
+
+@jax.custom_vjp
+def i_custom_vjp(x: jax.Array) -> jax.Array:
+    return jnp.sin(x)
+
+
+def i_custom_vjp_fwd(x: jax.Array):
+    # The residual *is* the input itself. JAX detects this and prunes it from
+    # the fwd rule's return value, recording the argument index in
+    # `input_forwards` instead -- this exercises the splice in
+    # `_custom_vjp_fwd_wrap` that reconstitutes forwarded residuals from
+    # `in_tracers` before flattening.
+    return jnp.sin(x), x
+
+
+def i_custom_vjp_bwd(res, ct):
+    # deliberately not `cos(res) * ct`, so this could not be produced by
+    # ordinary autodiff -- proves the custom (and forwarded) rule ran.
+    return (3.0 * res * ct,)
+
+
+i_custom_vjp.defvjp(i_custom_vjp_fwd, i_custom_vjp_bwd)
+
+
+def test_custom_vjp_fwd_forwards_input_as_residual():
+    """`jax.grad` through a custom_vjp whose fwd rule returns an input as its
+    own residual, exercising JAX's input-forwarding optimization."""
+    x_val = jnp.arange(1.0, 4.0)
+
+    got = jax.grad(lambda a: quax.quaxify(i_custom_vjp)(a).array.sum())(MyArray(x_val))
+
+    assert isinstance(got, MyArray)
+    assert jnp.allclose(got.array, 3.0 * x_val)

--- a/tests/usage/test_unitful.py
+++ b/tests/usage/test_unitful.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
+import pytest
 
 import quax
 from quax.examples.unitful import meters, seconds, Unitful
@@ -29,3 +30,30 @@ def test_integer_pow_units_and_values_agree():
     assert isinstance(out, Unitful)
     assert out.units == {meters: 3, seconds: -3}
     assert jnp.array_equal(out.array, jnp.array(8.0))
+
+
+def test_copy_preserves_units():
+    """`jnp.copy` keeps the units of its operand."""
+    x = Unitful(jnp.array([2.0, 3.0]), meters)
+
+    out = quax.quaxify(jnp.copy)(x)
+
+    assert isinstance(out, Unitful)
+    assert out.units == {meters: 1}
+    assert jnp.array_equal(out.array, jnp.array([2.0, 3.0]))
+
+
+def test_select_n_requires_matching_units():
+    """`jnp.where` between two Unitfuls keeps units, and rejects a mismatch."""
+    x = Unitful(jnp.array([2.0, 3.0]), meters)
+    y = Unitful(jnp.array([4.0, 5.0]), meters)
+    pred = jnp.array([True, False])
+
+    out = quax.quaxify(jnp.where)(pred, x, y)
+    assert isinstance(out, Unitful)
+    assert out.units == {meters: 1}
+    assert jnp.array_equal(out.array, jnp.array([2.0, 5.0]))
+
+    bad = Unitful(jnp.array([4.0, 5.0]), seconds)
+    with pytest.raises(ValueError, match="units"):
+        quax.quaxify(jnp.where)(pred, x, bad)

--- a/uv.lock
+++ b/uv.lock
@@ -1489,16 +1489,16 @@ docs = [
 ide = [
     { name = "ipykernel" },
 ]
-integration = [
+lint = [
+    { name = "prek" },
+    { name = "ruff" },
+]
+test-integration = [
     { name = "beartype" },
     { name = "diffrax" },
     { name = "jax" },
     { name = "pytest" },
     { name = "pytest-env" },
-]
-lint = [
-    { name = "prek" },
-    { name = "ruff" },
 ]
 tests = [
     { name = "beartype" },
@@ -1547,16 +1547,16 @@ docs = [
     { name = "zensical" },
 ]
 ide = [{ name = "ipykernel", specifier = ">=7.2.0" }]
-integration = [
+lint = [
+    { name = "prek", specifier = ">=0.3.11" },
+    { name = "ruff", specifier = ">=0.15.9" },
+]
+test-integration = [
     { name = "beartype", specifier = ">=0.20.2,<0.23.0" },
     { name = "diffrax", specifier = ">=0.7.2" },
     { name = "jax", extras = ["cpu"] },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-env", specifier = ">=1.1.5" },
-]
-lint = [
-    { name = "prek", specifier = ">=0.3.11" },
-    { name = "ruff", specifier = ">=0.15.9" },
 ]
 tests = [
     { name = "beartype", specifier = ">=0.20.2,<0.23.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -227,6 +227,24 @@ wheels = [
 ]
 
 [[package]]
+name = "diffrax"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "equinox" },
+    { name = "jax" },
+    { name = "jaxtyping" },
+    { name = "lineax" },
+    { name = "optimistix" },
+    { name = "typing-extensions" },
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/ea/a22853377a840d70d1d174d43183f12990c66eecf34ba7e76eec781249d0/diffrax-0.7.2.tar.gz", hash = "sha256:9adc70fe90dba83f7dd839845839b2531a3dd736a3944fe1aa26598507cfb48e", size = 155159, upload-time = "2026-02-18T01:14:04.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/48/c42f657f3d6b4d9d9674c9bc48e763d024511ea4cc1d6e0c68c7b4380c43/diffrax-0.7.2-py3-none-any.whl", hash = "sha256:1beee2f991cd049962fe3c89da28f933753aa66d80bef857533276c9f23301ed", size = 199673, upload-time = "2026-02-18T01:14:03.38Z" },
+]
+
+[[package]]
 name = "equinox"
 version = "0.13.8"
 source = { registry = "https://pypi.org/simple" }
@@ -545,6 +563,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "lineax"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "equinox" },
+    { name = "jax" },
+    { name = "jaxtyping" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/e0/b7e501899cebd6dc609a01645350afa7976d40a8f3c0bfdf4560e448b2b7/lineax-0.1.1.tar.gz", hash = "sha256:187b8ea93b8e1099fb792e81c6e71a9c269f4fcadbb5313fe312d5847f581f9d", size = 53195, upload-time = "2026-05-01T15:59:06.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/f8/0d32243c6b8e5dbee9097cf0c95bbdf8681ba4463c927c2e3445f3775814/lineax-0.1.1-py3-none-any.whl", hash = "sha256:2e399f1674773ab2ba54d76175a618977a554f47abd0a345198d53d92c07beb2", size = 77567, upload-time = "2026-05-01T15:59:05.517Z" },
 ]
 
 [[package]]
@@ -962,6 +995,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004, upload-time = "2024-09-26T14:33:24.483Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932, upload-time = "2024-09-26T14:33:23.039Z" },
+]
+
+[[package]]
+name = "optimistix"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "equinox" },
+    { name = "jax" },
+    { name = "jaxtyping" },
+    { name = "lineax" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/0b/3bdc0e698cb0d264e5dca0b5bb171342a950a43fa6e046d8c57189298422/optimistix-0.1.0.tar.gz", hash = "sha256:f05c9104748e87e1dc10a0b4a2be94e427f98c3eab0b1d41ea24a593d76be03d", size = 70164, upload-time = "2026-02-16T13:35:43.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/53/6a81a6ebb1739f19c32002139719d4ee021a349d5bdbe066910feed327a1/optimistix-0.1.0-py3-none-any.whl", hash = "sha256:c8edda7bf7fe48839c93fcd72bce750c950ed9f7033158303150b7ab395add81", size = 101740, upload-time = "2026-02-16T13:35:42.971Z" },
 ]
 
 [[package]]
@@ -1440,6 +1489,13 @@ docs = [
 ide = [
     { name = "ipykernel" },
 ]
+integration = [
+    { name = "beartype" },
+    { name = "diffrax" },
+    { name = "jax" },
+    { name = "pytest" },
+    { name = "pytest-env" },
+]
 lint = [
     { name = "prek" },
     { name = "ruff" },
@@ -1491,6 +1547,13 @@ docs = [
     { name = "zensical" },
 ]
 ide = [{ name = "ipykernel", specifier = ">=7.2.0" }]
+integration = [
+    { name = "beartype", specifier = ">=0.20.2,<0.23.0" },
+    { name = "diffrax", specifier = ">=0.7.2" },
+    { name = "jax", extras = ["cpu"] },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-env", specifier = ">=1.1.5" },
+]
 lint = [
     { name = "prek", specifier = ">=0.3.11" },
     { name = "ruff", specifier = ">=0.15.9" },


### PR DESCRIPTION
Adds `jax.custom_vjp` support to `quax`. It was the only entry left in the README's unsupported list.

## What changed

`_QuaxTrace.process_custom_vjp_call` in [`src/quax/_trace.py`](src/quax/_trace.py), alongside the existing `process_custom_jvp_call`. It flattens each input `Value` into leaves, wraps JAX's three sub-functions (`fun`, `fwd`, `bwd`) in `linear_util` transformations that re-inflate leaves into `Value`s inside a nested trace, and re-binds the primitive at leaf level.

Three details make it more than a copy of the jvp path:

- `fwd` is called with its arguments interleaved with per-argument "tangent is nonzero" flags, and returns residuals *before* primal outputs.
- The `out_trees` param is a thunk reporting residual/output **leaf** counts. Since quax changes the leaf count — one `Value` can flatten to several arrays — the trace substitutes its own thunk. It also has to undo JAX's input-forwarding pruning, splicing forwarded residuals back in before flattening.
- `DynamicJaxprTrace` resets `fwd`'s stores and re-traces, so the wrapper's store needs `use_eq_store=True`. This is what `jit(grad(...))` exercises.

Also here:

- `to_ct_aval` shim in [`src/quax/_compat.py`](src/quax/_compat.py) — `AbstractValue.to_ct_aval()` does not exist on the `jax>=0.7.2` floor; `to_tangent_aval()` is used there, behind a `hasattr` probe rather than a guessed version boundary.
- `copy_p` and `select_n_p` rules for the `Unitful` example type — both dimensionally principled (copying preserves units; selecting requires them to agree).
- A new `tests/integration` suite with its own `test-integration` dependency group and CI job.

## Tests

`tests/unit/test_custom_vjp.py` covers forward, `grad`, `jit(grad)`, `vmap`, `vmap(grad)`, two arguments, mixed `Value`/plain-array, `symbolic_zeros=True`, and JAX's input-forwarding path. Fixtures use deliberately scaled backward rules, so a test cannot pass by falling through to ordinary autodiff of the primal.

`tests/integration/test_diffrax_unitful.py` runs a `diffrax` Runge-Kutta integration under `quaxify` with `Unitful` state. That routes through `equinox.internal`'s buffered stage loop, which is built on `jax.custom_vjp` — so it is real evidence a downstream library exercises the new path, and one test asserts the dispatch count directly rather than inferring it.

Verified locally against every CI job: default suite on JAX 0.10.2 (1059 passed), the floor via `--resolution lowest-direct` on JAX 0.7.2 (1046 passed), the integration job (2 passed), and the skip path with diffrax absent (1 skipped, exit 0).

## Known limitations, documented in the README

Quax cannot see arrays a library pre-allocates without reference to your `Value` — a `jnp.zeros` scratch buffer — so values written into one come back out as plain arrays. Two consequences, both deferred to a follow-up PR and recorded with reproductions in the plan document's follow-up section:

1. A full `diffrax.diffeqsolve` under `quaxify` cannot complete: it allocates its `SaveAt` buffer from `filter_eval_shape` structs, so a later `lax.cond` has a `Value` in one branch and a plain buffer slice in the other. This is why the integration test drives `solver.step` directly. It is not units-specific — it reproduces with a plain dense `ArrayValue` too.
2. Reverse-mode AD through those buffered loops does not work. There are **two independent, layered gaps**: buffer erasure catches `Unitful` first, and behind it a traced-bool failure at `equinox/internal/_loop/checkpointed.py:766` remains even with a freely-materialising `Value`. Fixing the first alone would not restore reverse-mode. Three configurations pinning down where each one bites are recorded in the plan.

Forward-mode through `custom_vjp`-based libraries works, and ordinary `custom_vjp` functions differentiate correctly under `jax.grad`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
