### PR TITLE
fix(cond): materialise mismatched branch outputs instead of failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ primitive that Quax does not understand, open an issue or pull request.
 
 One known limitation: Quax cannot see arrays that a library pre-allocates
 without reference to your `Value` (e.g. a `jnp.zeros` scratch buffer). Values
-written into such a buffer come back out as plain arrays.
+written into such a buffer come back out as plain arrays. Where that forces a
+`lax.cond` branch to disagree with its siblings, Quax materialises the branch
+outputs rather than failing -- so a `Value` that refuses to materialise (like
+`quax.examples.unitful`) still stops there, by design.
 
 Another: forward-mode `quaxify` works through `custom_vjp`-based libraries
 (e.g. `diffrax`), and ordinary `custom_vjp` differentiates fine under

--- a/src/quax/_primitives.py
+++ b/src/quax/_primitives.py
@@ -14,7 +14,7 @@ from jaxtyping import ArrayLike
 from ._compat import is_early_inline, jit_p, scan_bind_params, unpack_scan_args
 from ._dispatch import register
 from ._quaxify import _Quaxify, quaxify
-from ._values import _make_cache_finalizer, ArrayValue
+from ._values import _is_value, _make_cache_finalizer, ArrayValue
 
 
 # Cache for jit_quax: maps (id(jaxpr), treedef) -> (jaxpr_wref, jitted_fn).
@@ -160,11 +160,9 @@ def cond_quax(
             out = quaxify(jexc.jaxpr_as_fun(jaxpr))(*_args)
             if materialise:
                 out = jtu.tree_map(
-                    lambda x: (
-                        type(x).materialise(x) if isinstance(x, ArrayValue) else x
-                    ),
+                    lambda x: type(x).materialise(x) if _is_value(x) else x,
                     out,
-                    is_leaf=lambda x: isinstance(x, ArrayValue),
+                    is_leaf=_is_value,
                 )
             flat_out, out_tree = jtu.tree_flatten(out)
             out_trees.append(out_tree)
@@ -176,7 +174,7 @@ def cond_quax(
 
     if any(t != out_trees[0] for t in out_trees[1:]):
         # The branches disagree on which outputs are `Value`s, and `cond_p`
-        # needs one structure. Retrace with every `ArrayValue` materialised --
+        # needs one structure. Retrace with every `Value` materialised --
         # the fallback `Value.default` already applies to any primitive with no
         # rule. A type that refuses to materialise raises from there instead.
         out_trees.clear()

--- a/src/quax/_primitives.py
+++ b/src/quax/_primitives.py
@@ -153,7 +153,7 @@ def cond_quax(
     out_trees: list[Any] = []
 
     def _make_quax_branch(
-        jaxpr: core.ClosedJaxpr, /, *, materialise: bool = False
+        jaxpr: core.ClosedJaxpr, /, *, materialise: bool
     ) -> core.ClosedJaxpr:
         def flat_quax_call(flat_args: list[Any]) -> list[Any]:
             _args = jtu.tree_unflatten(in_tree, flat_args)
@@ -170,7 +170,7 @@ def cond_quax(
 
         return jax.make_jaxpr(flat_quax_call)(flat_args)
 
-    quax_branches = tuple(_make_quax_branch(j) for j in branches)
+    quax_branches = tuple(_make_quax_branch(j, materialise=False) for j in branches)
 
     if any(t != out_trees[0] for t in out_trees[1:]):
         # The branches disagree on which outputs are `Value`s, and `cond_p`

--- a/src/quax/_primitives.py
+++ b/src/quax/_primitives.py
@@ -175,14 +175,10 @@ def cond_quax(
     quax_branches = tuple(_make_quax_branch(j) for j in branches)
 
     if any(t != out_trees[0] for t in out_trees[1:]):
-        # The branches disagree on which outputs are `Value`s -- typically one
-        # returns the carried `Value` while another returns a read of a buffer
-        # the caller pre-allocated without reference to it, which quax never saw
-        # and so cannot lift back into a `Value`. `cond_p` needs a single output
-        # structure, so retrace with every `ArrayValue` materialised: the same
-        # fallback `Value.default` applies to any primitive with no rule. A type
-        # that refuses to materialise raises from there, which reports the lost
-        # information far better than a pytree mismatch would.
+        # The branches disagree on which outputs are `Value`s, and `cond_p`
+        # needs one structure. Retrace with every `ArrayValue` materialised --
+        # the fallback `Value.default` already applies to any primitive with no
+        # rule. A type that refuses to materialise raises from there instead.
         out_trees.clear()
         quax_branches = tuple(_make_quax_branch(j, materialise=True) for j in branches)
         if any(t != out_trees[0] for t in out_trees[1:]):

--- a/src/quax/_primitives.py
+++ b/src/quax/_primitives.py
@@ -152,12 +152,21 @@ def cond_quax(
 
     out_trees: list[Any] = []
 
-    def _make_quax_branch(jaxpr: core.ClosedJaxpr, /) -> core.ClosedJaxpr:
+    def _make_quax_branch(
+        jaxpr: core.ClosedJaxpr, /, *, materialise: bool = False
+    ) -> core.ClosedJaxpr:
         def flat_quax_call(flat_args: list[Any]) -> list[Any]:
             _args = jtu.tree_unflatten(in_tree, flat_args)
-            flat_out, out_tree = jtu.tree_flatten(
-                quaxify(jexc.jaxpr_as_fun(jaxpr))(*_args)
-            )
+            out = quaxify(jexc.jaxpr_as_fun(jaxpr))(*_args)
+            if materialise:
+                out = jtu.tree_map(
+                    lambda x: (
+                        type(x).materialise(x) if isinstance(x, ArrayValue) else x
+                    ),
+                    out,
+                    is_leaf=lambda x: isinstance(x, ArrayValue),
+                )
+            flat_out, out_tree = jtu.tree_flatten(out)
             out_trees.append(out_tree)
             return flat_out
 
@@ -166,7 +175,18 @@ def cond_quax(
     quax_branches = tuple(_make_quax_branch(j) for j in branches)
 
     if any(t != out_trees[0] for t in out_trees[1:]):
-        raise TypeError("all branches output must have the same pytree.")
+        # The branches disagree on which outputs are `Value`s -- typically one
+        # returns the carried `Value` while another returns a read of a buffer
+        # the caller pre-allocated without reference to it, which quax never saw
+        # and so cannot lift back into a `Value`. `cond_p` needs a single output
+        # structure, so retrace with every `ArrayValue` materialised: the same
+        # fallback `Value.default` applies to any primitive with no rule. A type
+        # that refuses to materialise raises from there, which reports the lost
+        # information far better than a pytree mismatch would.
+        out_trees.clear()
+        quax_branches = tuple(_make_quax_branch(j, materialise=True) for j in branches)
+        if any(t != out_trees[0] for t in out_trees[1:]):
+            raise TypeError("all branches output must have the same pytree.")
 
     kwargs = {"linear": linear} if linear is not _sentinel else {}
     if branches_platforms is not _sentinel:

--- a/tests/integration/test_diffrax_dense.py
+++ b/tests/integration/test_diffrax_dense.py
@@ -1,0 +1,59 @@
+"""A full `diffrax.diffeqsolve` under `quaxify`.
+
+`diffeqsolve` allocates its `SaveAt` output buffer with `jnp.full`, so the
+buffer is a plain array no matter what the state is. A later `lax.cond` then
+puts a slice of that buffer opposite the carried `Value`, and the two branches
+disagree on structure. `cond_quax` used to reject that outright, which made
+`diffeqsolve` unreachable under `quaxify` for every state type; it now falls
+back to `materialise`, so any `Value` that materialises gets through.
+
+The state therefore arrives back as a plain array -- the buffer erased it --
+but the solve runs and the numbers are right, with no bridging rules
+registered at all. `test_diffrax_unitful.py` covers the other side: a `Value`
+that refuses to materialise still stops here, which is what it is for.
+"""
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+import quax
+
+
+diffrax = pytest.importorskip("diffrax")
+
+
+class Dense(quax.ArrayValue):
+    """An `ArrayValue` that materialises freely, as most real ones do."""
+
+    array: jax.Array = eqx.field(converter=jnp.asarray)
+
+    def materialise(self) -> jax.Array:
+        return self.array
+
+    def aval(self) -> jax.core.ShapedArray:
+        return jax.typeof(self.array)
+
+
+def _solve(y0):
+    term = diffrax.ODETerm(lambda t, y, args: -0.5 * y)
+    return diffrax.diffeqsolve(
+        term,
+        diffrax.Euler(),
+        t0=0.0,
+        t1=1.0,
+        dt0=0.1,
+        y0=y0,
+        saveat=diffrax.SaveAt(t1=True),
+    ).ys
+
+
+def test_diffeqsolve_completes_under_quaxify():
+    """The full solve runs and agrees with plain JAX."""
+    y0 = jnp.array([1.0])
+    expected = _solve(y0)
+
+    got = quax.quaxify(_solve)(Dense(y0))
+
+    assert jnp.allclose(got, expected)

--- a/tests/integration/test_diffrax_dense.py
+++ b/tests/integration/test_diffrax_dense.py
@@ -1,59 +1,36 @@
 """A full `diffrax.diffeqsolve` under `quaxify`.
 
-`diffeqsolve` allocates its `SaveAt` output buffer with `jnp.full`, so the
-buffer is a plain array no matter what the state is. A later `lax.cond` then
-puts a slice of that buffer opposite the carried `Value`, and the two branches
-disagree on structure. `cond_quax` used to reject that outright, which made
-`diffeqsolve` unreachable under `quaxify` for every state type; it now falls
-back to `materialise`, so any `Value` that materialises gets through.
-
-The state therefore arrives back as a plain array -- the buffer erased it --
-but the solve runs and the numbers are right, with no bridging rules
-registered at all. `test_diffrax_unitful.py` covers the other side: a `Value`
-that refuses to materialise still stops here, which is what it is for.
+`diffeqsolve` allocates its `SaveAt` buffer with `jnp.full`, so a `lax.cond`
+downstream puts a plain buffer slice opposite the carried `Value`. That used to
+be rejected outright; `cond_quax` now materialises instead, so any `Value` that
+materialises gets through -- as a plain array, but with the right numbers, and
+with no bridging rules registered. `test_diffrax_unitful.py` covers the type
+that refuses.
 """
 
-import equinox as eqx
-import jax
 import jax.numpy as jnp
 import pytest
 
 import quax
 
+from ..unit.myarray import DenseArray
+
 
 diffrax = pytest.importorskip("diffrax")
 
 
-class Dense(quax.ArrayValue):
-    """An `ArrayValue` that materialises freely, as most real ones do."""
-
-    array: jax.Array = eqx.field(converter=jnp.asarray)
-
-    def materialise(self) -> jax.Array:
-        return self.array
-
-    def aval(self) -> jax.core.ShapedArray:
-        return jax.typeof(self.array)
-
-
 def _solve(y0):
     term = diffrax.ODETerm(lambda t, y, args: -0.5 * y)
+    saveat = diffrax.SaveAt(t1=True)
     return diffrax.diffeqsolve(
-        term,
-        diffrax.Euler(),
-        t0=0.0,
-        t1=1.0,
-        dt0=0.1,
-        y0=y0,
-        saveat=diffrax.SaveAt(t1=True),
+        term, diffrax.Euler(), 0.0, 1.0, 0.1, y0, saveat=saveat
     ).ys
 
 
 def test_diffeqsolve_completes_under_quaxify():
     """The full solve runs and agrees with plain JAX."""
     y0 = jnp.array([1.0])
-    expected = _solve(y0)
 
-    got = quax.quaxify(_solve)(Dense(y0))
+    got = quax.quaxify(_solve)(DenseArray(y0))
 
-    assert jnp.allclose(got, expected)
+    assert jnp.allclose(got, _solve(y0))

--- a/tests/integration/test_diffrax_unitful.py
+++ b/tests/integration/test_diffrax_unitful.py
@@ -4,10 +4,12 @@
 loop, which is built on `jax.custom_vjp` -- so this exercises
 `quax._trace._QuaxTrace.process_custom_vjp_call`.
 
-`diffrax.diffeqsolve` is not used: it allocates its `SaveAt` buffer with
-`jnp.full`, which Quax never sees, so a later `lax.cond` puts a plain buffer
-slice opposite a `Value` and `cond_quax` rejects it. Driving `solver.step`
-keeps the numerics without the buffer.
+`diffrax.diffeqsolve` is not used *here*: it allocates its `SaveAt` buffer
+with `jnp.full`, which Quax never sees, so `Unitful` comes back out of it
+dimensionless -- and `Unitful` refuses to materialise, which is the whole
+point of it. Driving `solver.step` keeps the numerics without the buffer.
+`test_diffrax_dense.py` runs the full `diffeqsolve` with a type that does
+materialise.
 
 Forward direction only. `jax.grad` is blocked twice over: for `Unitful` it
 fails first at a `select_n` over mixed plain/`Unitful` operands (the same

--- a/tests/unit/myarray.py
+++ b/tests/unit/myarray.py
@@ -16,6 +16,26 @@ from quax._compat import JAX_GE_0_10_1, JAX_GE_0_11_0, JAX_VERSION, typeof
 
 
 @final
+class DenseArray(quax.ArrayValue):
+    """A :class:`quax.ArrayValue` that materialises freely.
+
+    :class:`MyArray` refuses to materialise, so it cannot exercise any path
+    that falls back to it. This one can, and behaves like most real
+    ``ArrayValue`` types in that respect.
+    """
+
+    array: jax.Array = eqx.field(converter=jnp.asarray)
+
+    def materialise(self) -> jax.Array:
+        """Convert to a JAX array."""
+        return self.array
+
+    def aval(self) -> jax.core.ShapedArray:
+        """Return the ShapedArray."""
+        return typeof(self.array)
+
+
+@final
 class MyArray(quax.ArrayValue):
     """A :class:`quax.ArrayValue` that is dense.
 

--- a/tests/usage/test_cond.py
+++ b/tests/usage/test_cond.py
@@ -1,3 +1,4 @@
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import pytest
@@ -153,3 +154,49 @@ def test_cond_grad_closure():
     assert p.units == {meters: 1}
     assert t.array == 1
     assert t.units == {meters: 1}
+
+
+class _Dense(quax.ArrayValue):
+    """An `ArrayValue` that materialises freely, as most real ones do."""
+
+    array: jax.Array = eqx.field(converter=jnp.asarray)
+
+    def materialise(self) -> jax.Array:
+        return self.array
+
+    def aval(self) -> jax.core.ShapedArray:
+        return jax.typeof(self.array)
+
+
+def _mixed_branches(x, pred):
+    """One branch carries the `Value`, the other a plain array.
+
+    Libraries hit this whenever they pre-allocate a buffer without reference to
+    the value going into it — a `jnp.zeros` scratch array read back in one
+    branch, the carried `Value` in the other.
+    """
+    return jax.lax.cond(pred, lambda: x, lambda: jnp.zeros(3))
+
+
+@pytest.mark.parametrize("pred", [True, False])
+def test_cond_mismatched_branches_materialise(pred):
+    """Branches disagreeing on `Value`-ness fall back to `materialise`.
+
+    This is the documented behaviour of `quax.Value.default` for any primitive
+    with no applicable rule; `cond_p` should not be an exception to it.
+    """
+    x = jnp.arange(3.0)
+    expected = _mixed_branches(x, jnp.array(pred))
+
+    got = quax.quaxify(_mixed_branches)(_Dense(x), jnp.array(pred))
+
+    assert not isinstance(got, quax.ArrayValue)
+    assert jnp.array_equal(got, expected)
+
+
+def test_cond_mismatched_branches_reports_refusal():
+    """A type that refuses to materialise says so, rather than "same pytree"."""
+    x = Unitful(jnp.arange(3.0), meters)
+
+    with pytest.raises(ValueError, match="Refusing to materialise"):
+        quax.quaxify(_mixed_branches)(x, jnp.array(True))

--- a/tests/usage/test_cond.py
+++ b/tests/usage/test_cond.py
@@ -1,10 +1,11 @@
-import equinox as eqx
 import jax
 import jax.numpy as jnp
 import pytest
 
 import quax
 from quax.examples.unitful import kilograms, meters, Unitful
+
+from ..unit.myarray import DenseArray
 
 
 def _outer_fn(a: jax.Array, b: jax.Array, c: jax.Array, pred: bool | jax.Array):
@@ -156,42 +157,24 @@ def test_cond_grad_closure():
     assert t.units == {meters: 1}
 
 
-class _Dense(quax.ArrayValue):
-    """An `ArrayValue` that materialises freely, as most real ones do."""
-
-    array: jax.Array = eqx.field(converter=jnp.asarray)
-
-    def materialise(self) -> jax.Array:
-        return self.array
-
-    def aval(self) -> jax.core.ShapedArray:
-        return jax.typeof(self.array)
-
-
 def _mixed_branches(x, pred):
-    """One branch carries the `Value`, the other a plain array.
-
-    Libraries hit this whenever they pre-allocate a buffer without reference to
-    the value going into it — a `jnp.zeros` scratch array read back in one
-    branch, the carried `Value` in the other.
-    """
+    """One branch carries the `Value`, the other a plain array."""
     return jax.lax.cond(pred, lambda: x, lambda: jnp.zeros(3))
 
 
-@pytest.mark.parametrize("pred", [True, False])
-def test_cond_mismatched_branches_materialise(pred):
+def test_cond_mismatched_branches_materialise():
     """Branches disagreeing on `Value`-ness fall back to `materialise`.
 
     This is the documented behaviour of `quax.Value.default` for any primitive
     with no applicable rule; `cond_p` should not be an exception to it.
     """
     x = jnp.arange(3.0)
-    expected = _mixed_branches(x, jnp.array(pred))
 
-    got = quax.quaxify(_mixed_branches)(_Dense(x), jnp.array(pred))
+    for pred in (True, False):
+        got = quax.quaxify(_mixed_branches)(DenseArray(x), jnp.array(pred))
 
-    assert not isinstance(got, quax.ArrayValue)
-    assert jnp.array_equal(got, expected)
+        assert not isinstance(got, quax.ArrayValue)
+        assert jnp.array_equal(got, _mixed_branches(x, jnp.array(pred)))
 
 
 def test_cond_mismatched_branches_reports_refusal():


### PR DESCRIPTION
Follow-up to #219, which documented this as a known limitation.

## Problem

`cond_quax` required every branch to return the same pytree:

```python
if any(t != out_trees[0] for t in out_trees[1:]):
    raise TypeError("all branches output must have the same pytree.")
```

Branches disagree whenever a library pre-allocates a buffer without reference to the value going into it — a `jnp.zeros` scratch array read back in one branch, the carried `Value` in the other. Quax never saw the allocation, so it cannot lift the plain side back into a `Value`.

`diffrax.diffeqsolve` hits exactly this through its `SaveAt` buffer, which made it unreachable under `quaxify` for **every** state type, not just unit-carrying ones.

## Fix

Retrace the branches with each `ArrayValue` materialised. That is already what `quax.Value.default` does for any primitive with no applicable rule:

> If precisely zero of the types of `value{1,2,3}` overloads this method, then all values are `quax.Value.materialise`d, and the usual JAX implementation is used.

So this makes `cond_p` consistent with the rest of dispatch rather than a special case. A `Value` that refuses to materialise still stops — now reporting `Refusing to materialise …`, which names the information that was actually lost, instead of a pytree mismatch that does not.

## Tests

- `tests/usage/test_cond.py` — a minimal `lax.cond` with one `Value` branch and one plain branch, for a type that materialises (passes through, both predicates) and one that refuses (reports the refusal).
- `tests/integration/test_diffrax_dense.py` — the full `diffeqsolve` under `quaxify`, which now completes and agrees with plain JAX. Notably it needs **no** bridging rules registered: a materialising `Value` gets through on the default fallback alone.

## Docs

`README.md` and `tests/integration/test_diffrax_unitful.py` both stated that `cond_quax` rejects this outright. Updated — the buffer still erases the `Value`, but it now degrades rather than failing.

## Verification

- `pytest tests/` with the integration group — 1079 passed, 135 skipped, 37 xfailed, 6 xpassed
- ruff check, ruff format, pyright, taplo pass on the changed files

(`ruff format --check` reports 7 pre-existing files repo-wide that also fail on a clean `main`; left alone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
