### PR TITLE
fix(trace): keep Python scalar residuals static through custom_vjp

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,10 @@ written into such a buffer come back out as plain arrays. Where that forces a
 outputs rather than failing -- so a `Value` that refuses to materialise (like
 `quax.examples.unitful`) still stops there, by design.
 
-Another: forward-mode `quaxify` works through `custom_vjp`-based libraries
-(e.g. `diffrax`), and ordinary `custom_vjp` differentiates fine under
-`jax.grad`, but reverse-mode through a library built on
-`equinox.internal.while_loop` (and so `diffrax`) currently runs into the
-buffer limitation above, and a second, independent gap sits behind it -- so
-fixing buffers alone would not be enough to make this differentiate.
+Reverse-mode works through `custom_vjp`-based libraries, including ones built
+on `equinox.internal.while_loop` such as `diffrax`. A `Value` still has to
+survive the buffer limitation above to get there: one that refuses to
+materialise will stop at the buffer rather than at the gradient.
 
 ## See also: other libraries in the JAX ecosystem
 

--- a/src/quax/_trace.py
+++ b/src/quax/_trace.py
@@ -1,7 +1,7 @@
 import functools as ft
 import itertools as it
 from collections.abc import Sequence
-from typing import Any, overload
+from typing import Any, Final, overload
 
 import equinox as eqx
 import jax._src.core as core
@@ -22,6 +22,12 @@ from ._dispatch import (
     _wrap_if_array,
 )
 from ._values import _dense, _DenseArrayValue, _is_value, T, Value
+
+
+# Hoisted: `isinstance(x, (bool, int, float, complex))` rebuilds the tuple on
+# every call -- the builtins are rebindable globals, so CPython cannot fold it --
+# and these checks run per residual and per cotangent leaf.
+_PY_SCALARS: Final = (bool, int, float, complex)
 
 
 class _QuaxTracer(core.Tracer):
@@ -404,7 +410,7 @@ def _custom_jvp_jvp_wrap(tag, in_treedef, *in_primals_and_tangents):
 
 def _keep_static(trace: "_QuaxTrace", x: Any) -> Any:
     """Leave Python scalars alone; densifying them would erase their staticness."""
-    return x if isinstance(x, (bool, int, float, complex)) else trace.to_value(x)
+    return x if isinstance(x, _PY_SCALARS) else trace.to_value(x)
 
 
 def _leaf_counts(treedef: jtu.PyTreeDef, /) -> list[int]:  # pyright: ignore[reportInvalidTypeForm]
@@ -496,9 +502,7 @@ def _custom_vjp_bwd_wrap(f, tag, in_treedef, in_leaf_avals, fwd_aux, *res_and_ct
     with core.take_current_trace() as parent_trace:
         trace = _QuaxTrace(parent_trace, tag)
         in_tracers = [
-            x
-            if type(x) is SZ or isinstance(x, (bool, int, float, complex))
-            else _QuaxTracer(trace, x)  # pyright: ignore[reportArgumentType]
+            x if type(x) is SZ or isinstance(x, _PY_SCALARS) else _QuaxTracer(trace, x)  # pyright: ignore[reportArgumentType]
             for x in (*res_values, *ct_values)
         ]
         with core.set_current_trace(trace):

--- a/src/quax/_trace.py
+++ b/src/quax/_trace.py
@@ -402,6 +402,11 @@ def _custom_jvp_jvp_wrap(tag, in_treedef, *in_primals_and_tangents):
     yield out_primals + out_tangents, out_primal_treedef
 
 
+def _keep_static(trace: "_QuaxTrace", x: Any) -> Any:
+    """Leave Python scalars alone; densifying them would erase their staticness."""
+    return x if isinstance(x, (bool, int, float, complex)) else trace.to_value(x)
+
+
 def _leaf_counts(treedef: jtu.PyTreeDef, /) -> list[int]:  # pyright: ignore[reportInvalidTypeForm]
     """Number of leaves contributed by each element of a flattened list."""
     return [child.num_leaves for child in treedef.children()]
@@ -457,7 +462,7 @@ def _custom_vjp_fwd_wrap(f, store, tag, in_treedef, out_trees, *in_leaves_and_nz
                 next(res_out) if idx is None else in_tracers[idx]
                 for idx in input_forwards
             ]
-            res_values = [trace.to_value(t) for t in res]
+            res_values = [_keep_static(trace, t) for t in res]
             out_values = [trace.to_value(t) for t in res_and_primals_out[n_res_out:]]
         del trace, in_tracers
 
@@ -491,7 +496,9 @@ def _custom_vjp_bwd_wrap(f, tag, in_treedef, in_leaf_avals, fwd_aux, *res_and_ct
     with core.take_current_trace() as parent_trace:
         trace = _QuaxTrace(parent_trace, tag)
         in_tracers = [
-            x if type(x) is SZ else _QuaxTracer(trace, x)  # pyright: ignore[reportArgumentType]
+            x
+            if type(x) is SZ or isinstance(x, (bool, int, float, complex))
+            else _QuaxTracer(trace, x)  # pyright: ignore[reportArgumentType]
             for x in (*res_values, *ct_values)
         ]
         with core.set_current_trace(trace):

--- a/src/quax/_trace.py
+++ b/src/quax/_trace.py
@@ -24,9 +24,6 @@ from ._dispatch import (
 from ._values import _dense, _DenseArrayValue, _is_value, T, Value
 
 
-# Hoisted: `isinstance(x, (bool, int, float, complex))` rebuilds the tuple on
-# every call -- the builtins are rebindable globals, so CPython cannot fold it --
-# and these checks run per residual and per cotangent leaf.
 _PY_SCALARS: Final = (bool, int, float, complex)
 
 

--- a/tests/unit/test_custom_vjp.py
+++ b/tests/unit/test_custom_vjp.py
@@ -192,11 +192,6 @@ def test_custom_vjp_fwd_forwards_input_as_residual():
     assert jnp.allclose(got.array, 3.0 * x_val)
 
 
-# A `custom_vjp` whose fwd rule stashes a Python `bool` among its residuals and
-# whose bwd rule branches on it with `if`. Libraries do this to carry structural
-# decisions from fwd to bwd -- `equinox.internal.while_loop` records per-leaf
-# perturbation flags this way. Densifying the flag into a traced `bool[]` makes
-# the `if` raise `TracerBoolConversionError`.
 @jax.custom_vjp
 def k_custom_vjp(x: jax.Array) -> jax.Array:
     return jnp.sin(x)
@@ -243,12 +238,7 @@ def _checkpointed_loop(y0):
 
 
 def test_custom_vjp_grad_through_equinox_checkpointed_loop():
-    """Reverse-mode works through a real `custom_vjp`-based library.
-
-    `equinox.internal.while_loop` carries per-leaf perturbation flags as Python
-    bools through its residuals and branches on them in its bwd rule; this is
-    the workload that motivated keeping such residuals static.
-    """
+    """Reverse-mode works through a real `custom_vjp`-based library."""
     y0 = jnp.array([1.0])
     expected = jax.grad(lambda y: _checkpointed_loop(y).sum())(y0)
 

--- a/tests/unit/test_custom_vjp.py
+++ b/tests/unit/test_custom_vjp.py
@@ -1,11 +1,12 @@
 """Tests for process_custom_vjp_call."""
 
+import equinox.internal as eqxi
 import jax
 import jax.numpy as jnp
 
 import quax
 
-from .myarray import MyArray
+from .myarray import DenseArray, MyArray
 
 
 @jax.custom_vjp
@@ -189,3 +190,73 @@ def test_custom_vjp_fwd_forwards_input_as_residual():
 
     assert isinstance(got, MyArray)
     assert jnp.allclose(got.array, 3.0 * x_val)
+
+
+# A `custom_vjp` whose fwd rule stashes a Python `bool` among its residuals and
+# whose bwd rule branches on it with `if`. Libraries do this to carry structural
+# decisions from fwd to bwd -- `equinox.internal.while_loop` records per-leaf
+# perturbation flags this way. Densifying the flag into a traced `bool[]` makes
+# the `if` raise `TracerBoolConversionError`.
+@jax.custom_vjp
+def k_custom_vjp(x: jax.Array) -> jax.Array:
+    return jnp.sin(x)
+
+
+def k_custom_vjp_fwd(x: jax.Array):
+    return jnp.sin(x), (jnp.cos(x), True)
+
+
+def k_custom_vjp_bwd(res, ct):
+    cos_x, flag = res
+    if flag:  # a Python `bool`, not a traced array
+        return (7.0 * cos_x * ct,)
+    return (cos_x * ct,)
+
+
+k_custom_vjp.defvjp(k_custom_vjp_fwd, k_custom_vjp_bwd)
+
+
+def test_custom_vjp_python_scalar_residual_stays_static():
+    """A Python scalar residual reaches the bwd rule as a Python scalar.
+
+    Densifying it into a traced array would make the `if` in the bwd rule raise
+    `TracerBoolConversionError`, and the `7.0` branch proves which path ran.
+    """
+    x_val = jnp.arange(1.0, 4.0)
+
+    got = jax.grad(lambda a: quax.quaxify(k_custom_vjp)(a).array.sum())(MyArray(x_val))
+
+    assert jnp.allclose(got.array, 7.0 * jnp.cos(x_val))
+
+
+def _checkpointed_loop(y0):
+    """`equinox.internal.while_loop`, which is built on `jax.custom_vjp`."""
+
+    def cond(carry):
+        return carry[0] < 3
+
+    def body(carry):
+        i, y = carry
+        return i + 1, y * 0.5
+
+    return eqxi.while_loop(cond, body, (0, y0), max_steps=4, kind="checkpointed")[1]
+
+
+def test_custom_vjp_grad_through_equinox_checkpointed_loop():
+    """Reverse-mode works through a real `custom_vjp`-based library.
+
+    `equinox.internal.while_loop` carries per-leaf perturbation flags as Python
+    bools through its residuals and branches on them in its bwd rule; this is
+    the workload that motivated keeping such residuals static.
+    """
+    y0 = jnp.array([1.0])
+    expected = jax.grad(lambda y: _checkpointed_loop(y).sum())(y0)
+
+    def _sum(y):
+        # the loop's output materialises on the way out of the buffer
+        out = quax.quaxify(_checkpointed_loop)(y)
+        return (out.array if isinstance(out, quax.ArrayValue) else out).sum()
+
+    got = jax.grad(_sum)(DenseArray(y0))
+
+    assert jnp.allclose(got.array, expected)


### PR DESCRIPTION
Follow-up to #219. Second of the two gaps that PR documented as blocking reverse-mode; #222 is the first.

## Problem

Libraries carry structural decisions from a `custom_vjp` fwd rule to its bwd rule as Python scalars in the residuals, then branch on them with `if`. `equinox.internal.while_loop` does this with per-leaf perturbation flags — so `diffrax` does too.

`_custom_vjp_fwd_wrap` sent every residual through `to_value`, which densifies a Python `bool` into `_DenseArrayValue(bool[])`. `_custom_vjp_bwd_wrap` then handed it back as `_QuaxTracer<bool[]>`, and equinox's

```python
jtu.tree_map(lambda x, p: jnp.zeros_like(x) if p else None, body_fun, perturb_body_fun)
```

raised `TracerBoolConversionError` — `p` being a `_QuaxTracer`, not a `bool`. Reverse-mode through any such library was unreachable under `quaxify`.

Diagnosis note: `equinox._ad._get_perturbed` returns a plain `bool` in both the plain-JAX and quaxified runs, so the flag is static when equinox produces it. Quax introduces the tracer downstream, in the residual round-trip.

## Fix

Leave Python scalars alone in both wrappers. Plain JAX keeps them static through the same path — densifying them was quax adding tracing nobody asked for.

## Tests

- `test_custom_vjp_python_scalar_residual_stays_static` — a `custom_vjp` whose fwd stashes a Python `bool` in its residuals and whose bwd branches on it. The taken branch scales by `7.0`, so the assertion proves *which* path ran, not merely that nothing raised. Fails on `main` with `TracerBoolConversionError`.
- `test_custom_vjp_grad_through_equinox_checkpointed_loop` — `jax.grad` through `equinox.internal.while_loop(kind="checkpointed")`, matching plain JAX. This is the motivating workload, and it needs no diffrax to reproduce. Also fails on `main`.

## Stacked on #222

Based on `claude/cond-branch-reconcile`, so review this PR's single commit; the diff shown is only this change. Merge #222 first.

With both, `jax.grad` through a full `diffrax.diffeqsolve` under `quaxify` matches plain JAX (`[0.59873694]` from both). Neither alone is sufficient — #222 clears the `SaveAt` buffer's `lax.cond`, this one clears the perturbation flags behind it.

The `DenseArray` test fixture comes from #222, which moved it into `tests/unit/myarray.py`; this PR imports it rather than defining its own.

## Verification

- `pytest tests/unit tests/usage` — 1070 passed, 135 skipped, 37 xfailed, 6 xpassed
- ruff check, ruff format, pyright pass on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

