### PR TITLE
refactor: dedupe sparse mul gather, drop no-op prng type aliases

### DIFF
--- a/src/quax/examples/prng/_core.py
+++ b/src/quax/examples/prng/_core.py
@@ -24,8 +24,6 @@ else:
 
 
 RealArray: TypeAlias = ArrayLike
-DTypeLikeFloat: TypeAlias = Any
-DTypeLikeInexact: TypeAlias = Any
 
 PRNG_T = TypeVar("PRNG_T", bound="PRNG")
 
@@ -79,7 +77,7 @@ ThreeFry.__init__.__doc__ = """**Arguments:**
 def uniform(
     key: PRNG,
     shape: tuple[int, ...] = (),
-    dtype: DTypeLikeFloat = jnp.float_,
+    dtype: Any = jnp.float_,
     minval: RealArray = 0.0,
     maxval: RealArray = 1.0,
 ) -> Float[Array, "..."]:
@@ -127,7 +125,7 @@ def uniform(
 
 
 def normal(
-    key: PRNG, shape: tuple[int, ...] = (), dtype: DTypeLikeInexact = jnp.float_
+    key: PRNG, shape: tuple[int, ...] = (), dtype: Any = jnp.float_
 ) -> Inexact[Array, "..."]:
     """Samples from a normal distribution.
 

--- a/src/quax/examples/sparse/_core.py
+++ b/src/quax/examples/sparse/_core.py
@@ -158,13 +158,7 @@ def _mul_bcoo_dense(x: BCOO, y: ArrayLike, /, **kw: Any) -> BCOO:
     assert isinstance(x, BCOO)
     assert isinstance(y, get_args(ArrayLike))
     y = jnp.asarray(y)
-    indices = tuple(jnp.moveaxis(x.indices, -1, 0))
-    # TODO: unify with _sparse_to_dense, above?
-    getindex = lambda a, b: a[b]
-    for _ in range(x.data.ndim - 1):
-        getindex = jax.vmap(getindex)
-    # ~
-    y_data = getindex(y, indices)
+    y_data = _op_sparse_to_dense(x, y, lambda a, b, _data: a[b])
     data = lax.mul_p.bind(x.data, y_data, **kw)
     return BCOO(data, x.indices, x.shape, x.allow_materialise)
 


### PR DESCRIPTION
## Summary
- `_mul_bcoo_dense` (sparse example) now reuses `_op_sparse_to_dense`'s batched-gather helper instead of re-implementing the same vmap loop, resolving the file's own `# TODO: unify with _sparse_to_dense, above?`.
- Dropped `DTypeLikeFloat`/`DTypeLikeInexact` (prng example) — both were `TypeAlias = Any`, adding a name but no type information. The two call sites now annotate `Any` directly.

Found via a repo-wide over-engineering audit; both are minor cleanups with no behavior change.

## Test plan
- [x] `pytest tests/usage/test_sparse.py tests/usage/test_prng.py` — 12 passed
- [x] `pytest tests/unit/test_examples_imports.py` — 2 passed
- [x] `ruff check` on changed files — clean
- [x] pre-commit hooks (ruff check/format, pyright) — passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)