### PR TITLE
test(unitful): cover select_n edge cases; name both units on mismatch

### DIFF
--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -162,7 +162,7 @@ else:
 
 
 # `AbstractValue.to_ct_aval` is absent on the `jax>=0.7.2` floor, where only
-# `to_tangent_aval` exists; the two coincide for shaped avals. Probed with
+# `to_tangent_aval` exists; they coincide on that floor. Probed with
 # `hasattr` because the release that added `to_ct_aval` is unverified.
 _HAS_TO_CT_AVAL: Final = hasattr(
     jax.core.ShapedArray,  # pyright: ignore[reportAttributeAccessIssue]

--- a/src/quax/examples/unitful/_core.py
+++ b/src/quax/examples/unitful/_core.py
@@ -102,9 +102,10 @@ def copy_unitful(x: Unitful, **kw: Any) -> Unitful:
 @quax.register(jax.lax.select_n_p)
 def select_n_unitful(which: ArrayLike, *cases: Unitful, **kw: Any) -> Unitful:
     units = cases[0].units
-    if any(c.units != units for c in cases[1:]):
-        raise ValueError(
-            f"Cannot select between arrays with units {[c.units for c in cases]}."
-        )
+    for case in cases[1:]:
+        if case.units != units:
+            raise ValueError(
+                f"Cannot select between arrays with units {units} and {case.units}."
+            )
     arrays = [c.array for c in cases]
     return Unitful(jax.lax.select_n_p.bind(which, *arrays, **kw), units)

--- a/tests/unit/test_custom_vjp.py
+++ b/tests/unit/test_custom_vjp.py
@@ -250,3 +250,19 @@ def test_custom_vjp_grad_through_equinox_checkpointed_loop():
     got = jax.grad(_sum)(DenseArray(y0))
 
     assert jnp.allclose(got.array, expected)
+
+
+def test_custom_vjp_vmap_grad_with_forwarded_residual():
+    """Batching and input-forwarding compose.
+
+    `batching.process_custom_vjp_call` rebuilds the bwd rule's input dimensions
+    from `out_trees()`'s forwarding list, so the splice in
+    `_custom_vjp_fwd_wrap` has to line up under `vmap` too.
+    """
+    xs_val = jnp.arange(1.0, 4.0)
+
+    got = jax.vmap(jax.grad(lambda a: quax.quaxify(i_custom_vjp)(a).array.sum()))(
+        MyArray(xs_val)
+    )
+
+    assert jnp.allclose(got.array, 3.0 * xs_val)

--- a/tests/usage/test_unitful.py
+++ b/tests/usage/test_unitful.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import pytest
 
@@ -57,3 +58,30 @@ def test_select_n_requires_matching_units():
     bad = Unitful(jnp.array([4.0, 5.0]), seconds)
     with pytest.raises(ValueError, match="units"):
         quax.quaxify(jnp.where)(pred, x, bad)
+
+
+def test_select_n_single_case_is_a_no_op():
+    """`select_n` with one case has nothing to disagree with, and passes through."""
+    x = Unitful(jnp.array([2.0, 3.0]), meters)
+
+    out = quax.quaxify(lambda w, a: jax.lax.select_n(w, a))(jnp.array(0), x)
+
+    assert isinstance(out, Unitful)
+    assert out.units == {meters: 1}
+    assert jnp.array_equal(out.array, jnp.array([2.0, 3.0]))
+
+
+def test_select_n_three_cases_checks_every_pair():
+    """A mismatch in the *third* case is caught, not just the second."""
+    a = Unitful(jnp.array([1.0]), meters)
+    b = Unitful(jnp.array([2.0]), meters)
+    bad = Unitful(jnp.array([3.0]), seconds)
+
+    which = jnp.array(0)
+    out = quax.quaxify(jax.lax.select_n)(which, a, b, Unitful(jnp.array([4.0]), meters))
+    assert isinstance(out, Unitful)
+    assert out.units == {meters: 1}
+
+    # the message names the two mismatching unit dicts, as `add_p`'s does
+    with pytest.raises(ValueError, match=r"units \{m: 1\} and \{s: 1\}"):
+        quax.quaxify(jax.lax.select_n)(which, a, b, bad)


### PR DESCRIPTION
Sweeps the minor findings deferred during #219's review. No behaviour change beyond one error message.

## `select_n_unitful` names the mismatching pair

It reported every case's units as a list:

```
Cannot select between arrays with units [{m: 1}, {m: 1}, {s: 1}].
```

Now it names the two that actually disagree, matching the phrasing the neighbouring `add_p` rule has used all along:

```
Cannot select between arrays with units {m: 1} and {s: 1}.
```

## Coverage for the paths nobody tested

`select_n` is N-ary but only the 2-case path (`jnp.where`) had a test. Adds the 1-case pass-through and a 3-case mismatch — the latter asserts the message names *both* unit dicts, so the phrasing is guarded rather than just the exception type.

Also adds `vmap` over the input-forwarding path in `tests/unit/test_custom_vjp.py`. `batching.process_custom_vjp_call` rebuilds the bwd rule's input dimensions from `out_trees()`'s forwarding list, so the splice in `_custom_vjp_fwd_wrap` has to line up under `vmap` too. It already did — this pins it.

## One claim narrowed

`_compat` said `to_ct_aval` and `to_tangent_aval` "coincide for shaped avals". They can diverge under `shard_map` with manual axis types on newer JAX — where the `hasattr` probe takes the real method anyway. Narrowed to "coincide on that floor", which is where the fallback actually runs.

## One finding deliberately not fixed

The `# pyright: ignore[reportInvalidTypeForm]` on `_leaf_counts` stays. `jtu.PyTreeDef` is a variable rather than a class, so pyright rejects it in a type expression; I tried the alternatives, and the only spellings that pass are `Any` or dropping the annotation, both of which say less than the suppressed one does. #219's final review reached the same conclusion.

## Verification

- `pytest tests/` — 1076 passed, 136 skipped, 37 xfailed, 6 xpassed
- ruff check, ruff format, pyright pass on the changed files

Stacked on #223 (which is stacked on #222), so the diff shown is only this change. Merge order: #222 -> #223 -> #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

