### PR TITLE
docs: correct the reverse-mode note now that only one gap remains

### DIFF
--- a/tests/integration/test_diffrax_unitful.py
+++ b/tests/integration/test_diffrax_unitful.py
@@ -11,12 +11,11 @@ point of it. Driving `solver.step` keeps the numerics without the buffer.
 `test_diffrax_dense.py` runs the full `diffeqsolve` with a type that does
 materialise.
 
-Forward direction only. `jax.grad` is blocked twice over: for `Unitful` it
-fails first at a `select_n` over mixed plain/`Unitful` operands (the same
-buffer erasure the `add_p` rules below work around), and behind that, even a
-freely-materialising `ArrayValue` hits `TracerBoolConversionError` inside
-equinox at `_loop/checkpointed.py:766`. Fixing the first would not fix the
-second. Ordinary `custom_vjp` reverse-mode is unaffected; see
+Forward direction only, and for one reason: `jax.grad` reaches a `select_n`
+over mixed plain/`Unitful` operands -- the same buffer erasure the `add_p`
+rules below work around -- where `Unitful` refuses to materialise, which is
+what it is for. Reverse-mode itself is fine, including through
+`equinox.internal.while_loop`; see `test_diffrax_dense.py` and
 `tests/unit/test_custom_vjp.py`.
 """
 


### PR DESCRIPTION
Post-merge cleanup after #222 and #223.

## Problem

`tests/integration/test_diffrax_unitful.py` still says:

> `jax.grad` is blocked twice over … and behind that, even a freely-materialising `ArrayValue` hits `TracerBoolConversionError` inside equinox at `_loop/checkpointed.py:766`. **Fixing the first would not fix the second.**

#223 fixed the second. As written it warns the next reader off a fix that has already landed.

## What is actually true now

Verified rather than assumed — running the module's own `_step_n` under `jax.grad` with `Unitful`:

```
ValueError: Refusing to materialise Unitful array.
  innermost frame: src/quax/examples/unitful/_core.py:42, in materialise
```

One gap left, and it is `Unitful`-specific *by design*: `select_n` over mixed plain/`Unitful` operands falls through to `materialise`, which `Unitful` refuses — that refusal being the entire point of the example. Reverse-mode itself is fine, including through `equinox.internal.while_loop`, as `tests/integration/test_diffrax_dense.py` and `tests/unit/test_custom_vjp.py` both cover.

`README.md` needed no change; #223 already rewrote its reverse-mode paragraph.

## Verification

`pytest tests/integration` — 3 passed. Docstring only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
