### PR TITLE
test: reduce duplication with fixtures and parametrization

### DIFF
--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -20,6 +20,11 @@ already-parsed positional paths (``config.args``) inside ``pytest_ignore_collect
 
 from pathlib import Path
 
+import jax
+import pytest
+
+import quax
+
 
 _HERE = Path(__file__).parent.resolve()
 
@@ -65,3 +70,17 @@ def pytest_ignore_collect(collection_path, config):
         return True  # no benchmark plugin -> never collect benchmarks
 
     return None if _explicitly_targeted(config) else True
+
+
+@pytest.fixture()
+def bench(benchmark):
+    """Warm ``quax.quaxify(fn, **kwargs)(*args)`` once, then hand the steady-state
+    call to ``benchmark``. Pass ``jit=True`` to ``jax.jit``-wrap ``fn`` before
+    quaxifying it, for benchmarks that need the compiled steady-state path."""
+
+    def _bench(fn, *args, jit=False, **kwargs):
+        qfn = quax.quaxify(jax.jit(fn) if jit else fn, **kwargs)
+        qfn(*args)  # warm up
+        benchmark(lambda: qfn(*args))
+
+    return _bench

--- a/tests/benchmark/test_autodiff.py
+++ b/tests/benchmark/test_autodiff.py
@@ -47,22 +47,18 @@ _xm = MyArray(jnp.arange(8.0) + 1)
 
 
 @pytest.mark.benchmark(group="autodiff")
-def test_custom_jvp_forward(benchmark):
+def test_custom_jvp_forward(bench):
     """`quaxify` over a `custom_jvp` function — `process_custom_jvp_call` +
     `_custom_jvp_fun_wrap` (forward only; the jvp rule is never entered)."""
-    qfn = quax.quaxify(_custom_jvp_fn)
-    qfn(_xm)  # warm the dispatch cache
-    benchmark(lambda: qfn(_xm))
+    bench(_custom_jvp_fn, _xm)
 
 
 @pytest.mark.benchmark(group="autodiff")
-def test_custom_jvp_grad(benchmark):
+def test_custom_jvp_grad(bench):
     """`quaxify(grad(custom_jvp fn))` — additionally exercises
     `_custom_jvp_jvp_wrap`: the tangent `SymbolicZero` scan and the
     primal/tangent class reconciliation."""
-    qfn = quax.quaxify(eqx.filter_grad(lambda a: jnp.sum(_custom_jvp_fn(a))))
-    qfn(_xm)
-    benchmark(lambda: qfn(_xm))
+    bench(eqx.filter_grad(lambda a: jnp.sum(_custom_jvp_fn(a))), _xm)
 
 
 @jax.custom_vjp
@@ -82,22 +78,18 @@ _custom_vjp_fn.defvjp(_custom_vjp_fn_fwd, _custom_vjp_fn_bwd)
 
 
 @pytest.mark.benchmark(group="autodiff")
-def test_custom_vjp_forward(benchmark):
+def test_custom_vjp_forward(bench):
     """`quaxify` over a `custom_vjp` function — `process_custom_vjp_call` +
     `_custom_vjp_fun_wrap` (forward only; fwd/bwd are never entered)."""
-    qfn = quax.quaxify(_custom_vjp_fn)
-    qfn(_xm)  # warm the dispatch cache
-    benchmark(lambda: qfn(_xm))
+    bench(_custom_vjp_fn, _xm)
 
 
 @pytest.mark.benchmark(group="autodiff")
-def test_custom_vjp_grad(benchmark):
+def test_custom_vjp_grad(bench):
     """`quaxify(grad(custom_vjp fn))` — additionally exercises
     `_custom_vjp_fwd_wrap` (residual re-splicing, the substituted `out_trees`
     thunk) and `_custom_vjp_bwd_wrap` (per-leaf cotangent expansion)."""
-    qfn = quax.quaxify(eqx.filter_grad(lambda a: jnp.sum(_custom_vjp_fn(a))))
-    qfn(_xm)
-    benchmark(lambda: qfn(_xm))
+    bench(eqx.filter_grad(lambda a: jnp.sum(_custom_vjp_fn(a))), _xm)
 
 
 _key = jr.PRNGKey(0)

--- a/tests/benchmark/test_construction.py
+++ b/tests/benchmark/test_construction.py
@@ -48,27 +48,24 @@ class _CustomInit(quax.ArrayValue):
 
 
 @pytest.mark.benchmark(group="construction")
-def test_construct_dense_factory(benchmark):
-    """Internal fast-path allocation (``_dense``) — bypasses the metaclass."""
-    benchmark(_dense, _arr)
+@pytest.mark.parametrize(
+    "ctor",
+    [_dense, _DenseArrayValue, MyArray, _CustomInit],
+    ids=["dense_factory", "dense_value", "user_dataclass_init", "user_custom_init"],
+)
+def test_construct(benchmark, ctor):
+    """Construct each Value flavor from the same array.
 
-
-@pytest.mark.benchmark(group="construction")
-def test_construct_dense_value(benchmark):
-    """Direct ``_DenseArrayValue(...)`` construction (through the metaclass)."""
-    benchmark(_DenseArrayValue, _arr)
-
-
-@pytest.mark.benchmark(group="construction")
-def test_construct_user_dataclass_init(benchmark):
-    """User ``Value`` with a converter and dataclass-generated ``__init__``."""
-    benchmark(MyArray, _arr)
-
-
-@pytest.mark.benchmark(group="construction")
-def test_construct_user_custom_init(benchmark):
-    """User ``Value`` with a custom ``__init__`` and ``__check_init__``."""
-    benchmark(_CustomInit, _arr)
+    - ``dense_factory``: internal fast-path allocation (``_dense``) — bypasses
+      the metaclass.
+    - ``dense_value``: direct ``_DenseArrayValue(...)`` construction (through
+      the metaclass).
+    - ``user_dataclass_init``: user ``Value`` with a converter and
+      dataclass-generated ``__init__``.
+    - ``user_custom_init``: user ``Value`` with a custom ``__init__`` and
+      ``__check_init__``.
+    """
+    benchmark(ctor, _arr)
 
 
 # =============================================================================

--- a/tests/benchmark/test_control_flow.py
+++ b/tests/benchmark/test_control_flow.py
@@ -20,8 +20,6 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-import quax
-
 from ..unit.myarray import MyArray
 
 
@@ -31,38 +29,31 @@ _while_init = MyArray(jnp.array(0.0))
 _cond_x = MyArray(jnp.arange(8.0) + 1)
 
 
-def _bench(benchmark, fn, *args):
-    """Warm the jit + dispatch caches, then benchmark the steady-state call."""
-    qfn = quax.quaxify(jax.jit(fn))
-    qfn(*args)  # compile the body and fill the quax caches
-    benchmark(lambda: qfn(*args))
-
-
 @pytest.mark.benchmark(group="control_flow")
-def test_scan(benchmark):
+def test_scan(bench):
     """`quaxify(jit(...))` over a `lax.scan` — exercises `scan_quax` + its cache."""
 
     def f(init, xs):
         return jax.lax.scan(lambda c, x: (c + x, c * x), init, xs)
 
-    _bench(benchmark, f, _scan_init, _scan_xs)
+    bench(f, _scan_init, _scan_xs, jit=True)
 
 
 @pytest.mark.benchmark(group="control_flow")
-def test_while(benchmark):
+def test_while(bench):
     """`quaxify(jit(...))` over a `lax.while_loop` — exercises `while_quax`."""
 
     def f(x):
         return jax.lax.while_loop(lambda c: c < 5.0, lambda c: c + 1.0, x)
 
-    _bench(benchmark, f, _while_init)
+    bench(f, _while_init, jit=True)
 
 
 @pytest.mark.benchmark(group="control_flow")
-def test_cond(benchmark):
+def test_cond(bench):
     """`quaxify(jit(...))` over a `lax.switch` — exercises `cond_quax`."""
 
     def f(index, x):
         return jax.lax.switch(index, [lambda a: a + 1.0, lambda a: a * 2.0], x)
 
-    _bench(benchmark, f, 0, _cond_x)
+    bench(f, 0, _cond_x, jit=True)

--- a/tests/benchmark/test_dispatch.py
+++ b/tests/benchmark/test_dispatch.py
@@ -61,44 +61,37 @@ def _calls_inner_jit(a):
     return _inner_jit(a)
 
 
-def _bench(benchmark, fn, *args):
-    """Warm the dispatch cache, then benchmark eager ``quaxify(fn)(*args)``."""
-    qfn = quax.quaxify(fn)
-    qfn(*args)  # warm plum resolution + the dispatch cache
-    benchmark(lambda: qfn(*args))
-
-
 @pytest.mark.benchmark(group="dispatch")
-def test_add_myarray(benchmark):
+def test_add_myarray(bench):
     """`quaxify(add)(MyArray, MyArray)` — the core single-primitive dispatch."""
-    _bench(benchmark, lambda a, b: a + b, _xm, _ym)
+    bench(lambda a, b: a + b, _xm, _ym)
 
 
 @pytest.mark.benchmark(group="dispatch")
-def test_mul_myarray(benchmark):
+def test_mul_myarray(bench):
     """`quaxify(mul)(MyArray, MyArray)`."""
-    _bench(benchmark, lambda a, b: a * b, _xm, _ym)
+    bench(lambda a, b: a * b, _xm, _ym)
 
 
 @pytest.mark.benchmark(group="dispatch")
-def test_add_zero(benchmark):
+def test_add_zero(bench):
     """`quaxify(add)(Zero, array)` — the symbolic-zero fast rule."""
-    _bench(benchmark, lambda a, b: a + b, _z, _arr)
+    bench(lambda a, b: a + b, _z, _arr)
 
 
 @pytest.mark.benchmark(group="dispatch")
-def test_mul_unitful(benchmark):
+def test_mul_unitful(bench):
     """`quaxify(mul)(Unitful, Unitful)` — a rule that does real Python work
     (merging the unit dicts) on top of the array op."""
-    _bench(benchmark, lambda a, b: a * b, _u, _u)
+    bench(lambda a, b: a * b, _u, _u)
 
 
 @pytest.mark.benchmark(group="dispatch")
-def test_materialise_fallback(benchmark):
+def test_materialise_fallback(bench):
     """`quaxify(sin)(LoraArray)` — no rule for this (primitive, type), so the
     cached `_DISPATCH_MISS` sends it to `_default_process`, which materialises
     every `Value` operand and binds the primitive on plain arrays."""
-    _bench(benchmark, jnp.sin, _lora_mat)
+    bench(jnp.sin, _lora_mat)
 
 
 @pytest.mark.benchmark(group="dispatch")
@@ -110,14 +103,14 @@ def test_nested_quaxify_add(benchmark):
 
 
 @pytest.mark.benchmark(group="dispatch")
-def test_matmul_lora(benchmark):
+def test_matmul_lora(bench):
     """`quaxify(dot_general)(LoraArray, array)` — LoRA matmul (many primitives,
     inlined pjits)."""
-    _bench(benchmark, lax.dot_general, _lora, _rhs, _dot_dn)
+    bench(lax.dot_general, _lora, _rhs, _dot_dn)
 
 
 @pytest.mark.benchmark(group="dispatch")
-def test_jit_cache_hit(benchmark):
+def test_jit_cache_hit(bench):
     """`quaxify` over a function calling an inner `@jax.jit` — the cached
     (non-inlined) `jit_quax` path, hitting `_jit_quax_cache`."""
-    _bench(benchmark, _calls_inner_jit, _xm)
+    bench(_calls_inner_jit, _xm)

--- a/tests/benchmark/test_quaxify.py
+++ b/tests/benchmark/test_quaxify.py
@@ -32,32 +32,26 @@ _ym = MyArray(_arr + 1)
 
 
 @pytest.mark.benchmark(group="quaxify")
-def test_no_value_shortcut(benchmark):
+def test_no_value_shortcut(bench):
     """`quaxify(f)(array)` with no `Value` anywhere — the short-circuit that
     skips the trace entirely, leaving only the `tree_leaves` scan."""
-    qfn = quax.quaxify(lambda a, b: a + b)
-    qfn(_arr, _arr)
-    benchmark(lambda: qfn(_arr, _arr))
+    bench(lambda a, b: a + b, _arr, _arr)
 
 
 @pytest.mark.benchmark(group="quaxify")
-def test_filter_spec_partition(benchmark):
+def test_filter_spec_partition(bench):
     """`quaxify(..., filter_spec=False)` — `_partition_and_wrap`'s general
     branch (`eqx.partition` + `eqx.combine`), passing the `Value`s through to a
     nested `quaxify` (the redispatch pattern)."""
     inner = quax.quaxify(lambda a, b: a + b)
-    outer = quax.quaxify(lambda a, b: inner(a, b), filter_spec=False)
-    outer(_xm, _ym)
-    benchmark(lambda: outer(_xm, _ym))
+    bench(lambda a, b: inner(a, b), _xm, _ym, filter_spec=False)
 
 
 _tree = [MyArray(_arr) for _ in range(32)]
 
 
 @pytest.mark.benchmark(group="quaxify")
-def test_wide_pytree(benchmark):
+def test_wide_pytree(bench):
     """32 `Value`s in one argument pytree — the `tree_map` wrap/unwrap passes,
     plus 32 primitives' worth of dispatch."""
-    qfn = quax.quaxify(lambda ts: [a + a for a in ts])
-    qfn(_tree)
-    benchmark(lambda: qfn(_tree))
+    bench(lambda ts: [a + a for a in ts], _tree)

--- a/tests/test_skill_examples.py
+++ b/tests/test_skill_examples.py
@@ -5,27 +5,54 @@ An example that stops running as JAX moves is a real defect, so every
 shared namespace, because later snippets build on names bound by earlier ones.
 Illustrative fragments that are not meant to run are fenced as ````py```` rather
 than ````python````, and are skipped.
+
+Each block gets its own parametrized test case (so a failure in block 3 doesn't
+hide whether blocks 4+ would have passed), but all blocks still execute in
+order into one shared namespace via a module-scoped fixture -- later blocks
+depend on names bound by earlier ones, so they can't run independently.
 """
 
 import re
 from pathlib import Path
 
+import pytest
+
 
 SKILL = Path(__file__).parents[1] / "skills" / "quax" / "SKILL.md"
 BLOCK = re.compile(r"^```python\n(.*?)^```", re.DOTALL | re.MULTILINE)
+# Explicit encoding: the skill contains non-ASCII punctuation (µ, —, ≤, ×),
+# and `read_text()` would otherwise decode it with the platform default.
+BLOCKS = BLOCK.findall(SKILL.read_text(encoding="utf-8"))
 
 
-def test_skill_examples_run():
-    """Every ```python block in the skill executes without error."""
-    # Explicit encoding: the skill contains non-ASCII punctuation (µ, —, ≤, ×),
-    # and `read_text()` would otherwise decode it with the platform default.
-    blocks = BLOCK.findall(SKILL.read_text(encoding="utf-8"))
-    assert blocks, f"no ```python blocks found in {SKILL} -- has the skill moved?"
+def test_skill_has_python_blocks():
+    """Sanity check that the extraction regex still matches -- has the skill moved?"""
+    assert BLOCKS, f"no ```python blocks found in {SKILL}"
 
+
+@pytest.fixture(scope="module")
+def block_outcomes() -> list[Exception | None]:
+    """Execute every block once, in order, into one shared namespace.
+
+    Returns the exception raised by each block (or None on success) so
+    individual tests can report per-block results without re-running anything.
+    """
     namespace: dict[str, object] = {}
-    for i, block in enumerate(blocks):
+    outcomes: list[Exception | None] = []
+    for i, block in enumerate(BLOCKS):
         try:
             exec(compile(block, f"{SKILL.name}[block {i}]", "exec"), namespace)  # noqa: S102
-        except Exception as exc:
-            msg = f"{SKILL.name} block {i} failed: {exc!r}\n\n{block}"
-            raise AssertionError(msg) from exc
+        except Exception as exc:  # noqa: BLE001
+            outcomes.append(exc)
+        else:
+            outcomes.append(None)
+    return outcomes
+
+
+@pytest.mark.parametrize("i", range(len(BLOCKS)))
+def test_skill_example_block(block_outcomes: list[Exception | None], i: int):
+    """Each ```python block in the skill executes without error."""
+    exc = block_outcomes[i]
+    if exc is not None:
+        msg = f"{SKILL.name} block {i} failed: {exc!r}\n\n{BLOCKS[i]}"
+        raise AssertionError(msg) from exc

--- a/tests/unit/_markers.py
+++ b/tests/unit/_markers.py
@@ -1,0 +1,32 @@
+"""Shared pytest marks for the `test_lax`/`test_numpy` function-coverage tables.
+
+These were previously redefined identically in each of test_lax/test_jax_array.py,
+test_lax/test_myarray.py, test_numpy/test_jax_array.py, and test_numpy/test_myarray.py.
+"""
+
+import pytest
+from packaging.version import Version
+
+from quax._compat import JAX_VERSION
+
+
+mark_todo = pytest.mark.skip(reason="TODO")
+mark_nomd = pytest.mark.xfail(reason="Can't be supported with MD on primitives")
+xfail_quax58 = pytest.mark.xfail(
+    reason="https://github.com/patrick-kidger/quax/issues/58"
+)
+skip_removed_jax_0_10_0 = pytest.mark.skipif(
+    JAX_VERSION >= Version("0.10"),
+    reason="removed in JAX v0.10.0",
+)
+xfail_deprecated_jax_0_9_0 = (
+    pytest.mark.xfail(
+        Version("0.9") <= JAX_VERSION < Version("0.10"),
+        raises=DeprecationWarning,
+        reason="deprecated in JAX v0.9.0",
+        strict=True,
+    ),
+    # Promote DeprecationWarning to an error so the xfail `raises` check works;
+    # warnings.warn() alone won't trigger raises= without this.
+    pytest.mark.filterwarnings("error::DeprecationWarning"),
+)

--- a/tests/unit/test_aval_binds_primitive.py
+++ b/tests/unit/test_aval_binds_primitive.py
@@ -11,6 +11,7 @@ import jax
 import jax.core
 import jax.lax as lax
 import jax.numpy as jnp
+import pytest
 from jaxtyping import Array
 
 import quax
@@ -36,24 +37,26 @@ def mul_stop_grad_array_stop_grad_array(
     return StopGradArray(lax.mul_p.bind(x.array, y.array, **kw))
 
 
-def test_wrapped_as_input():
+@pytest.fixture
+def x():
+    return StopGradArray(jnp.arange(3.0))
+
+
+def test_wrapped_as_input(x):
     """The input wrapping in `_Quaxify.__call__` computes `aval()`."""
-    x = StopGradArray(jnp.arange(3.0))
     out = quax.quaxify(lambda a: a + 1)(x)
     assert jnp.array_equal(out, jnp.arange(3.0) + 1)
 
 
-def test_returned_from_rule():
+def test_returned_from_rule(x):
     """Wrapping a rule's output back into a tracer computes `aval()` too."""
-    x = StopGradArray(jnp.arange(3.0))
     out = quax.quaxify(lambda a: a * a)(x)
     assert isinstance(out, StopGradArray)
     assert jnp.array_equal(out.array, jnp.arange(3.0) ** 2)
 
 
-def test_under_jit():
+def test_under_jit(x):
     """Same, with a non-trivial parent trace."""
-    x = StopGradArray(jnp.arange(3.0))
     out = jax.jit(quax.quaxify(lambda a: a * a))(x)
     assert isinstance(out, StopGradArray)
     assert jnp.array_equal(out.array, jnp.arange(3.0) ** 2)

--- a/tests/unit/test_custom_jvp.py
+++ b/tests/unit/test_custom_jvp.py
@@ -14,6 +14,21 @@ from quax._compat import typeof
 from .myarray import MyArray
 
 
+@pytest.fixture
+def x_val():
+    return jnp.array(1.0)
+
+
+@pytest.fixture
+def x2_val():
+    return jnp.array(2.0)
+
+
+@pytest.fixture
+def y2_val():
+    return jnp.array(3.0)
+
+
 # A simple function decorated with @jax.custom_jvp for testing
 @jax.custom_jvp
 def f_custom_jvp(x: jax.Array) -> jax.Array:
@@ -40,9 +55,8 @@ def g_custom_jvp_jvp(primals, tangents):
     return x * y, x * y_dot + y * x_dot
 
 
-def test_custom_jvp_forward():
+def test_custom_jvp_forward(x_val):
     """Forward pass through quaxified function with custom_jvp and MyArray input."""
-    x_val = jnp.array(1.0)
     expected = f_custom_jvp(x_val)
 
     x = MyArray(x_val)
@@ -52,23 +66,20 @@ def test_custom_jvp_forward():
     assert jnp.allclose(got.array, expected)
 
 
-def test_custom_jvp_forward_two_args():
+def test_custom_jvp_forward_two_args(x2_val, y2_val):
     """Forward pass with two MyArray args through custom_jvp."""
-    x_val = jnp.array(2.0)
-    y_val = jnp.array(3.0)
-    expected = g_custom_jvp(x_val, y_val)
+    expected = g_custom_jvp(x2_val, y2_val)
 
-    x = MyArray(x_val)
-    y = MyArray(y_val)
+    x = MyArray(x2_val)
+    y = MyArray(y2_val)
     got = quax.quaxify(g_custom_jvp)(x, y)
 
     assert isinstance(got, MyArray)
     assert jnp.allclose(got.array, expected)
 
 
-def test_custom_jvp_jvp():
+def test_custom_jvp_jvp(x_val):
     """jax.jvp through quaxified custom_jvp function with MyArray."""
-    x_val = jnp.array(1.0)
     t_val = jnp.array(1.0)
 
     expected_p, expected_t = jax.jvp(f_custom_jvp, (x_val,), (t_val,))
@@ -84,9 +95,8 @@ def test_custom_jvp_jvp():
     assert jnp.allclose(tangent_out.array, expected_t)
 
 
-def test_custom_jvp_grad():
+def test_custom_jvp_grad(x_val):
     """jax.grad through quaxified custom_jvp function with MyArray."""
-    x_val = jnp.array(1.0)
     expected_grad = jax.grad(f_custom_jvp)(x_val)
 
     def scalar_fn(x: MyArray) -> jax.Array:
@@ -145,17 +155,14 @@ def test_custom_jvp_symbolic_zeros_jvp():
     assert jnp.allclose(tangent_out.array, expected_t)
 
 
-def test_custom_jvp_symbolic_zeros_grad():
+def test_custom_jvp_symbolic_zeros_grad(x2_val, y2_val):
     """jax.grad through quaxified symbolic_zeros custom_jvp (SZ for y tangent)."""
-    x_val = jnp.array(2.0)
-    y_val = jnp.array(3.0)
-
-    expected_grad = jax.grad(lambda x: h_sym(x, y_val))(x_val)
+    expected_grad = jax.grad(lambda x: h_sym(x, y2_val))(x2_val)
 
     def fn(x: MyArray) -> jax.Array:
-        return quax.quaxify(h_sym)(x, MyArray(y_val)).array
+        return quax.quaxify(h_sym)(x, MyArray(y2_val)).array
 
-    got_grad = jax.grad(fn)(MyArray(x_val))
+    got_grad = jax.grad(fn)(MyArray(x2_val))
 
     assert isinstance(got_grad, MyArray)
     assert jnp.allclose(got_grad.array, expected_grad)
@@ -166,33 +173,29 @@ def test_custom_jvp_symbolic_zeros_grad():
 # ---------------------------------------------------------------------------
 
 
-def test_custom_jvp_mixed_value_and_array():
+def test_custom_jvp_mixed_value_and_array(x2_val, y2_val):
     """One MyArray operand and one plain array still dispatches through the
     custom_jvp rule (only the all-plain case short-circuits, see #58)."""
-    x_val = jnp.array(2.0)
-    y_val = jnp.array(3.0)
-    expected = g_custom_jvp(x_val, y_val)
+    expected = g_custom_jvp(x2_val, y2_val)
 
-    got = quax.quaxify(g_custom_jvp)(MyArray(x_val), y_val)
+    got = quax.quaxify(g_custom_jvp)(MyArray(x2_val), y2_val)
 
     assert isinstance(got, MyArray)
     assert jnp.allclose(got.array, expected)
 
 
-def test_custom_jvp_grad_both_argnums():
+def test_custom_jvp_grad_both_argnums(x2_val, y2_val):
     """jax.grad w.r.t. both arguments of a two-argument custom_jvp."""
-    x_val = jnp.array(2.0)
-    y_val = jnp.array(3.0)
 
     def fn(x: MyArray, y: MyArray) -> jax.Array:
         return quax.quaxify(g_custom_jvp)(x, y).array
 
-    gx, gy = jax.grad(fn, argnums=(0, 1))(MyArray(x_val), MyArray(y_val))
+    gx, gy = jax.grad(fn, argnums=(0, 1))(MyArray(x2_val), MyArray(y2_val))
 
     # d(x*y)/dx = y, d(x*y)/dy = x
     assert isinstance(gx, MyArray) and isinstance(gy, MyArray)
-    assert jnp.allclose(gx.array, y_val)
-    assert jnp.allclose(gy.array, x_val)
+    assert jnp.allclose(gx.array, y2_val)
+    assert jnp.allclose(gy.array, x2_val)
 
 
 def test_custom_jvp_vmap():

--- a/tests/unit/test_custom_vjp.py
+++ b/tests/unit/test_custom_vjp.py
@@ -2,10 +2,21 @@
 
 import jax
 import jax.numpy as jnp
+import pytest
 
 import quax
 
 from .myarray import MyArray
+
+
+@pytest.fixture
+def x_val():
+    return jnp.arange(1.0, 4.0)
+
+
+@pytest.fixture
+def y_val():
+    return jnp.arange(2.0, 5.0)
 
 
 @jax.custom_vjp
@@ -25,9 +36,8 @@ def f_custom_vjp_bwd(res, ct):
 f_custom_vjp.defvjp(f_custom_vjp_fwd, f_custom_vjp_bwd)
 
 
-def test_custom_vjp_forward():
+def test_custom_vjp_forward(x_val):
     """Forward pass through a quaxified custom_vjp function with MyArray input."""
-    x_val = jnp.arange(1.0, 4.0)
     expected = f_custom_vjp(x_val)
 
     got = quax.quaxify(f_custom_vjp)(MyArray(x_val))
@@ -36,10 +46,8 @@ def test_custom_vjp_forward():
     assert jnp.allclose(got.array, expected)
 
 
-def test_custom_vjp_grad_uses_custom_rule():
+def test_custom_vjp_grad_uses_custom_rule(x_val):
     """`jax.grad` through a quaxified custom_vjp uses the user's bwd rule."""
-    x_val = jnp.arange(1.0, 4.0)
-
     got = jax.grad(lambda a: quax.quaxify(f_custom_vjp)(a).array.sum())(MyArray(x_val))
 
     assert isinstance(got, MyArray)
@@ -63,20 +71,16 @@ def g_custom_vjp_bwd(res, ct):
 g_custom_vjp.defvjp(g_custom_vjp_fwd, g_custom_vjp_bwd)
 
 
-def test_custom_vjp_two_args_forward():
+def test_custom_vjp_two_args_forward(x_val, y_val):
     """Forward pass with two MyArray arguments."""
-    x_val, y_val = jnp.arange(1.0, 4.0), jnp.arange(2.0, 5.0)
-
     got = quax.quaxify(g_custom_vjp)(MyArray(x_val), MyArray(y_val))
 
     assert isinstance(got, MyArray)
     assert jnp.allclose(got.array, x_val * y_val)
 
 
-def test_custom_vjp_grad_both_argnums():
+def test_custom_vjp_grad_both_argnums(x_val, y_val):
     """`jax.grad` w.r.t. both arguments of a two-argument custom_vjp."""
-    x_val, y_val = jnp.arange(1.0, 4.0), jnp.arange(2.0, 5.0)
-
     got = jax.grad(
         lambda a, b: quax.quaxify(g_custom_vjp)(a, b).array.sum(), argnums=(0, 1)
     )(MyArray(x_val), MyArray(y_val))
@@ -85,20 +89,16 @@ def test_custom_vjp_grad_both_argnums():
     assert jnp.allclose(got[1].array, x_val)
 
 
-def test_custom_vjp_mixed_value_and_array():
+def test_custom_vjp_mixed_value_and_array(x_val, y_val):
     """A quaxified custom_vjp accepts a mix of MyArray and plain arrays."""
-    x_val, y_val = jnp.arange(1.0, 4.0), jnp.arange(2.0, 5.0)
-
     got = quax.quaxify(g_custom_vjp)(MyArray(x_val), y_val)
 
     assert isinstance(got, MyArray)
     assert jnp.allclose(got.array, x_val * y_val)
 
 
-def test_custom_vjp_jit_grad():
+def test_custom_vjp_jit_grad(x_val):
     """`jax.jit` around `jax.grad` re-traces the fwd rule without store errors."""
-    x_val = jnp.arange(1.0, 4.0)
-
     got = jax.jit(jax.grad(lambda a: quax.quaxify(f_custom_vjp)(a).array.sum()))(
         MyArray(x_val)
     )
@@ -106,25 +106,21 @@ def test_custom_vjp_jit_grad():
     assert jnp.allclose(got.array, 100.0 * jnp.cos(x_val))
 
 
-def test_custom_vjp_vmap():
+def test_custom_vjp_vmap(x_val, y_val):
     """`jax.vmap` over a quaxified custom_vjp batches correctly."""
-    xs_val, ys_val = jnp.arange(1.0, 4.0), jnp.arange(2.0, 5.0)
-
-    got = jax.vmap(quax.quaxify(g_custom_vjp))(MyArray(xs_val), MyArray(ys_val))
+    got = jax.vmap(quax.quaxify(g_custom_vjp))(MyArray(x_val), MyArray(y_val))
 
     assert isinstance(got, MyArray)
-    assert jnp.allclose(got.array, xs_val * ys_val)
+    assert jnp.allclose(got.array, x_val * y_val)
 
 
-def test_custom_vjp_vmap_grad():
+def test_custom_vjp_vmap_grad(x_val, y_val):
     """`jax.vmap` of `jax.grad` through a quaxified custom_vjp."""
-    xs_val, ys_val = jnp.arange(1.0, 4.0), jnp.arange(2.0, 5.0)
-
     got = jax.vmap(jax.grad(lambda a, b: quax.quaxify(g_custom_vjp)(a, b).array.sum()))(
-        MyArray(xs_val), MyArray(ys_val)
+        MyArray(x_val), MyArray(y_val)
     )
 
-    assert jnp.allclose(got.array, ys_val)
+    assert jnp.allclose(got.array, y_val)
 
 
 # A custom_vjp declared with `symbolic_zeros=True`: the fwd rule receives
@@ -146,10 +142,8 @@ def h_custom_vjp_bwd(res, ct):
 h_custom_vjp.defvjp(h_custom_vjp_fwd, h_custom_vjp_bwd, symbolic_zeros=True)
 
 
-def test_custom_vjp_symbolic_zeros():
+def test_custom_vjp_symbolic_zeros(x_val, y_val):
     """`symbolic_zeros=True`, including a `None` cotangent for one argument."""
-    x_val, y_val = jnp.arange(1.0, 4.0), jnp.arange(2.0, 5.0)
-
     got = jax.grad(lambda a, b: quax.quaxify(h_custom_vjp)(a, b).array.sum())(
         MyArray(x_val), MyArray(y_val)
     )
@@ -180,11 +174,9 @@ def i_custom_vjp_bwd(res, ct):
 i_custom_vjp.defvjp(i_custom_vjp_fwd, i_custom_vjp_bwd)
 
 
-def test_custom_vjp_fwd_forwards_input_as_residual():
+def test_custom_vjp_fwd_forwards_input_as_residual(x_val):
     """`jax.grad` through a custom_vjp whose fwd rule returns an input as its
     own residual, exercising JAX's input-forwarding optimization."""
-    x_val = jnp.arange(1.0, 4.0)
-
     got = jax.grad(lambda a: quax.quaxify(i_custom_vjp)(a).array.sum())(MyArray(x_val))
 
     assert isinstance(got, MyArray)

--- a/tests/unit/test_jax_compat.py
+++ b/tests/unit/test_jax_compat.py
@@ -17,126 +17,46 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
-def test_typed_int_conversion():
-    """Test that TypedInt can be converted to jax.Array."""
-    from jax._src.literals import TypedInt
+@pytest.mark.parametrize(
+    ("cls_name", "value", "dtype"),
+    [
+        ("TypedInt", 5, np.dtype(np.int32)),
+        ("TypedFloat", 3.14, np.dtype(np.float32)),
+        ("TypedComplex", 1 + 2j, np.dtype(np.complex64)),
+        ("TypedInt", 0, np.dtype(np.int32)),
+        ("TypedFloat", -2.5, np.dtype(np.float32)),
+        ("TypedComplex", 0j, np.dtype(np.complex64)),
+        ("TypedInt", 2**30, np.dtype(np.int32)),
+        ("TypedFloat", 1.23456789, np.dtype(np.float32)),
+        ("TypedComplex", 3j, np.dtype(np.complex64)),
+    ],
+    ids=[
+        "int-basic",
+        "float-basic",
+        "complex-basic",
+        "int-zero",
+        "float-negative",
+        "complex-zero",
+        "int-large-value",
+        "float-precision",
+        "complex-with-imaginary",
+    ],
+)
+def test_typed_conversion(cls_name, value, dtype):
+    """TypedInt/TypedFloat/TypedComplex convert to jax.Array, preserving
+    value and dtype. Floats use an isclose check (float32 precision);
+    ints/complex compare exactly."""
+    literals = importlib.import_module("jax._src.literals")
+    cls = getattr(literals, cls_name)
 
-    # Create a TypedInt
-    ti = TypedInt(5, np.dtype(np.int32))
-
-    # Convert to Array using plum
+    ti = cls(value, dtype)
     arr = plum.convert(ti, jnp.ndarray)
 
-    # Verify value and dtype are preserved
-    assert arr.item() == 5
-    assert arr.dtype == np.int32
-
-
-@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
-def test_typed_float_conversion():
-    """Test that TypedFloat can be converted to jax.Array."""
-    from jax._src.literals import TypedFloat
-
-    # Create a TypedFloat
-    tf = TypedFloat(3.14, np.dtype(np.float32))
-
-    # Convert to Array using plum
-    arr = plum.convert(tf, jnp.ndarray)
-
-    # Verify value and dtype are preserved
-    assert np.isclose(arr.item(), 3.14, rtol=1e-6)
-    assert arr.dtype == np.float32
-
-
-@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
-def test_typed_complex_conversion():
-    """Test that TypedComplex can be converted to jax.Array."""
-    from jax._src.literals import TypedComplex
-
-    # Create a TypedComplex
-    tc = TypedComplex(1 + 2j, np.dtype(np.complex64))
-
-    # Convert to Array using plum
-    arr = plum.convert(tc, jnp.ndarray)
-
-    # Verify value and dtype are preserved
-    assert arr.item() == (1 + 2j)
-    assert arr.dtype == np.complex64
-
-
-@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
-def test_typed_int_zero():
-    """Test TypedInt conversion with zero value."""
-    from jax._src.literals import TypedInt
-
-    ti = TypedInt(0, np.dtype(np.int32))
-    arr = plum.convert(ti, jnp.ndarray)
-
-    assert arr.item() == 0
-    assert arr.dtype == np.int32
-
-
-@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
-def test_typed_float_negative():
-    """Test TypedFloat conversion with negative value."""
-    from jax._src.literals import TypedFloat
-
-    tf = TypedFloat(-2.5, np.dtype(np.float32))
-    arr = plum.convert(tf, jnp.ndarray)
-
-    assert np.isclose(arr.item(), -2.5, rtol=1e-6)
-    assert arr.dtype == np.float32
-
-
-@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
-def test_typed_complex_zero():
-    """Test TypedComplex conversion with zero value."""
-    from jax._src.literals import TypedComplex
-
-    tc = TypedComplex(0j, np.dtype(np.complex64))
-    arr = plum.convert(tc, jnp.ndarray)
-
-    assert arr.item() == 0j
-    assert arr.dtype == np.complex64
-
-
-@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
-def test_typed_int_large_value():
-    """Test TypedInt conversion with large value that fits in int32."""
-    from jax._src.literals import TypedInt
-
-    # Use a value that fits in int32 (max int32 is 2^31 - 1)
-    ti = TypedInt(2**30, np.dtype(np.int32))
-    arr = plum.convert(ti, jnp.ndarray)
-
-    assert arr.item() == 2**30
-    assert arr.dtype == np.int32
-
-
-@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
-def test_typed_float_precision():
-    """Test TypedFloat conversion preserves precision for float32."""
-    from jax._src.literals import TypedFloat
-
-    tf = TypedFloat(1.23456789, np.dtype(np.float32))
-    arr = plum.convert(tf, jnp.ndarray)
-
-    # float32 has ~7 decimal digits of precision
-    assert np.isclose(arr.item(), 1.23456789, rtol=1e-6)
-    assert arr.dtype == np.float32
-
-
-@pytest.mark.skipif(not JAX_GE_0_8_0, reason="JAX >= 0.8.0 required")
-def test_typed_complex_with_imaginary():
-    """Test TypedComplex conversion with pure imaginary number."""
-    from jax._src.literals import TypedComplex
-
-    tc = TypedComplex(3j, np.dtype(np.complex64))
-    arr = plum.convert(tc, jnp.ndarray)
-
-    assert arr.item() == 3j
-    assert arr.dtype == np.complex64
+    if cls_name == "TypedFloat":
+        assert np.isclose(arr.item(), value, rtol=1e-6)
+    else:
+        assert arr.item() == value
+    assert arr.dtype == dtype
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_jit_quax_cache.py
+++ b/tests/unit/test_jit_quax_cache.py
@@ -37,6 +37,18 @@ from .myarray import MyArray
 _v = MyArray
 
 
+@pytest.fixture
+def inner_add_one():
+    """A fresh `@jax.jit` function of `x + 1.0`, with the cache cleared first."""
+    _jit_quax_cache.clear()
+
+    @jax.jit
+    def inner(x):
+        return x + 1.0
+
+    return inner
+
+
 def _extract_jit_jaxpr(closed_jaxpr: Any) -> Any:
     """Return the ClosedJaxpr param from the first jit_p equation, or None."""
     for eqn in closed_jaxpr.jaxpr.eqns:
@@ -98,34 +110,22 @@ def test_jaxpr_id_differs_for_different_avals():
     )
 
 
-def test_jit_quax_cache_populates_on_first_call():
+def test_jit_quax_cache_populates_on_first_call(inner_add_one):
     """The first quaxify call involving an inner @jax.jit function adds an
     entry to _jit_quax_cache."""
-    _jit_quax_cache.clear()
-
-    @jax.jit
-    def inner(x):
-        return x + 1.0
-
-    quax.quaxify(inner)(_v(jnp.array(0.0)))
+    quax.quaxify(inner_add_one)(_v(jnp.array(0.0)))
     assert len(_jit_quax_cache) > 0, "Cache was not populated on first call."
 
 
-def test_jit_quax_cache_hit_same_avals():
+def test_jit_quax_cache_hit_same_avals(inner_add_one):
     """A second quaxify call with the same argument avals hits the existing
     cache entry and does not add a new one."""
-    _jit_quax_cache.clear()
-
-    @jax.jit
-    def inner(x):
-        return x + 1.0
-
     x = _v(jnp.array(0.0))
-    quax.quaxify(inner)(x)
+    quax.quaxify(inner_add_one)(x)
     size_after_first = len(_jit_quax_cache)
     assert size_after_first > 0
 
-    quax.quaxify(inner)(x)
+    quax.quaxify(inner_add_one)(x)
     assert len(_jit_quax_cache) == size_after_first, (
         "Cache grew on the second call with identical avals — expected a hit."
     )
@@ -211,21 +211,16 @@ def test_jit_quax_cache_stable_while_jaxpr_alive():
 # ---------------------------------------------------------------------------
 
 
-def test_jit_inside_jit_populates_cache():
+def test_jit_inside_jit_populates_cache(inner_add_one):
     """A quaxified outer @jax.jit that calls an inner @jax.jit produces at
     least two _jit_quax_cache entries — one for the outer jit_p equation and
     one for the inner jit_p equation encountered while tracing the outer body.
     This exercises the JIT-inside-JIT population path described in the module
     docstring, which is distinct from the single-level cache-hit tests above."""
-    _jit_quax_cache.clear()
-
-    @jax.jit
-    def inner(x):
-        return x + 1.0
 
     @jax.jit
     def outer(x):
-        return inner(x)
+        return inner_add_one(x)
 
     result = quax.quaxify(outer)(_v(jnp.array(0.0)))
     assert float(result.array) == 1.0  # correct answer
@@ -241,20 +236,15 @@ def test_jit_inside_jit_populates_cache():
 # ---------------------------------------------------------------------------
 
 
-def test_inline_true_bypasses_cache():
+def test_inline_true_bypasses_cache(inner_add_one):
     """jit_p with inline=True takes the early-return path in jit_quax and
     must not read from or write to _jit_quax_cache.  We call jit_quax
     directly with inline=True to avoid any JAX-version sensitivity around
     when jax.jit(inline=True) produces a jit_p equation vs. inlines at
     trace time."""
-    _jit_quax_cache.clear()
-
-    @jax.jit
-    def inner(x):
-        return x + 1.0
 
     def outer(x):
-        return inner(x)
+        return inner_add_one(x)
 
     # Extract the ClosedJaxpr that jit_p carries for inner — same object
     # _QuaxTrace would pass to jit_quax via process_primitive.
@@ -288,20 +278,15 @@ def test_inline_true_bypasses_cache():
         ("AUTO", False),
     ],
 )
-def test_inline_enum_members(member, inlines):
+def test_inline_enum_members(member, inlines, inner_add_one):
     """From JAX 0.11.0 `inline` is a `jax.Inline` enum rather than a bool.
     Only `JAX_EARLY` (the old `True`) takes the early-return path; every other
     member keeps the call in the jaxpr and so must populate the cache, like the
     old `False` did.  Enum members are all truthy, so a plain `if inline:`
     would wrongly inline every one of them."""
-    _jit_quax_cache.clear()
-
-    @jax.jit
-    def inner(x):
-        return x + 1.0
 
     def outer(x):
-        return inner(x)
+        return inner_add_one(x)
 
     closed_outer = jax.make_jaxpr(outer)(jnp.array(0.0))
     inner_jaxpr = _extract_jit_jaxpr(closed_outer)

--- a/tests/unit/test_lax/test_jax_array.py
+++ b/tests/unit/test_lax/test_jax_array.py
@@ -7,8 +7,8 @@ from jax import lax
 
 import quax
 
+from .._markers import mark_todo
 
-mark_todo = pytest.mark.skip(reason="TODO")
 
 x = jnp.array([[1, 2], [3, 4]], dtype=float)
 y = jnp.array([[5, 6], [7, 8]], dtype=float)
@@ -20,6 +20,17 @@ xround = jnp.array([[1.1, 2.2], [3.3, 4.4]])
 conv_kernel = jnp.array([[[[1.0, 0.0], [0.0, -1.0]]]], dtype=float)
 xcomp = jnp.array([[5, 2], [7, 2]], dtype=float)
 xconv = jnp.arange(1, 17, dtype=float).reshape((1, 1, 4, 4))
+
+
+def _run_and_compare(module, func_name, args, kw):
+    func = getattr(module, func_name)
+    exp = func(*args, **kw)
+    exp = exp if isinstance(exp, tuple | list) else (exp,)
+
+    got = quax.quaxify(func)(*args, **kw)
+    got = got if isinstance(got, tuple | list) else (got,)
+
+    assert jtu.all(jtu.map(jnp.array_equal, got, exp))
 
 
 @pytest.mark.parametrize(
@@ -216,10 +227,7 @@ xconv = jnp.arange(1, 17, dtype=float).reshape((1, 1, 4, 4))
 )
 def test_lax_functions(func_name, args, kw):
     """Test lax vs qlax functions."""
-    func = getattr(lax, func_name)
-    exp = func(*args, **kw)
-    got = quax.quaxify(func)(*args, **kw)
-    assert jnp.array_equal(got, exp)
+    _run_and_compare(lax, func_name, args, kw)
 
 
 ###############################################################################
@@ -251,13 +259,4 @@ x1225 = jnp.array([[1, 2], [2, 5]], dtype=float)
 )
 def test_lax_linalg_functions(func_name, args, kw):
     """Test lax vs qlax functions."""
-    # JAX
-    func = getattr(lax.linalg, func_name)
-    exp = func(*args, **kw)
-    exp = exp if isinstance(exp, tuple | list) else (exp,)
-
-    # Quaxed
-    got = quax.quaxify(func)(*args, **kw)
-    got = got if isinstance(got, tuple | list) else (got,)
-
-    assert jtu.all(jtu.map(jnp.array_equal, got, exp))
+    _run_and_compare(lax.linalg, func_name, args, kw)

--- a/tests/unit/test_lax/test_myarray.py
+++ b/tests/unit/test_lax/test_myarray.py
@@ -7,10 +7,9 @@ from jax import lax
 
 import quax
 
+from .._markers import mark_todo
 from ..myarray import is_myarray, MyArray, unwrap
 
-
-mark_todo = pytest.mark.skip(reason="TODO")
 
 x = MyArray(jnp.array([[1, 2], [3, 4]], dtype=float))
 y = MyArray(jnp.array([[5, 6], [7, 8]], dtype=float))
@@ -57,6 +56,21 @@ def _unwrap_myarray(
     ]
     got = jtu.unflatten(tree_def, got_flat)
     return got
+
+
+def _run_and_compare(module, func_name, args, kw, expect_myarray, *, cmp=jnp.allclose):
+    # Jax version
+    func = getattr(module, func_name)
+    jax_args, jax_kw = jtu.map(unwrap, (args, kw), is_leaf=is_myarray)
+    exp = func(*jax_args, **jax_kw)
+    exp = exp if isinstance(exp, tuple | list) else (exp,)
+
+    # Quaxed version
+    got = quax.quaxify(func)(*args, **kw)
+    got = got if isinstance(got, tuple | list) else (got,)
+    got_ = _unwrap_myarray(got, expect_myarray)
+
+    assert jtu.all(jtu.map(cmp, got_, exp))
 
 
 @pytest.mark.parametrize(
@@ -281,18 +295,7 @@ def _unwrap_myarray(
 )
 def test_lax_functions(func_name, args, kw, expect_myarray):
     """Test lax vs qlax functions."""
-    # Jax version
-    func = getattr(lax, func_name)
-    jax_args, jax_kw = jtu.map(unwrap, (args, kw), is_leaf=is_myarray)
-    exp = func(*jax_args, **jax_kw)
-    exp = exp if isinstance(exp, tuple | list) else (exp,)
-
-    # Quaxed version
-    got = quax.quaxify(func)(*args, **kw)
-    got = got if isinstance(got, tuple | list) else (got,)
-    got_ = _unwrap_myarray(got, expect_myarray)
-
-    assert jtu.all(jtu.map(jnp.allclose, got_, exp))
+    _run_and_compare(lax, func_name, args, kw, expect_myarray)
 
 
 def test_cond() -> None:
@@ -336,15 +339,6 @@ def test_map() -> None:
 )
 def test_lax_linalg_functions(func_name, args, kw, expect_myarray):
     """Test lax vs qlax functions."""
-    # Jax version
-    func = getattr(lax.linalg, func_name)
-    jax_args, jax_kw = jtu.map(unwrap, (args, kw), is_leaf=is_myarray)
-    exp = func(*jax_args, **jax_kw)
-    exp = exp if isinstance(exp, tuple | list) else (exp,)
-
-    # Quaxed version
-    got = quax.quaxify(func)(*args, **kw)
-    got = got if isinstance(got, tuple | list) else (got,)
-    got_ = _unwrap_myarray(got, expect_myarray)
-
-    assert all(jnp.array_equal(g, e) for g, e in zip(got_, exp, strict=False))
+    _run_and_compare(
+        lax.linalg, func_name, args, kw, expect_myarray, cmp=jnp.array_equal
+    )

--- a/tests/unit/test_numpy/test_jax_array.py
+++ b/tests/unit/test_numpy/test_jax_array.py
@@ -4,33 +4,27 @@ import jax.numpy as jnp
 import jax.tree as jtu
 import numpy as np
 import pytest
-from packaging.version import Version
 
 from quax import quaxify
-from quax._compat import JAX_VERSION
 
+from .._markers import mark_todo, skip_removed_jax_0_10_0, xfail_deprecated_jax_0_9_0
 
-mark_todo = pytest.mark.skip("TODO")
-skip_removed_jax_0_10_0 = pytest.mark.skipif(
-    JAX_VERSION >= Version("0.10"),
-    reason="removed in JAX v0.10.0",
-)
-xfail_deprecated_jax_0_9_0 = (
-    pytest.mark.xfail(
-        Version("0.9") <= JAX_VERSION < Version("0.10"),
-        raises=DeprecationWarning,
-        reason="deprecated in JAX v0.9.0",
-        strict=True,
-    ),
-    # Promote DeprecationWarning to an error so the xfail `raises` check works;
-    # warnings.warn() alone won't trigger raises= without this.
-    pytest.mark.filterwarnings("error::DeprecationWarning"),
-)
 
 x = jnp.array([[1, 2], [3, 4]], dtype=float)
 y = jnp.array([[5, 6], [7, 8]], dtype=float)
 xtrig = jnp.array([[0.1, 0.2], [0.3, 0.4]], dtype=float)
 xbool = jnp.array([True, False, True], dtype=bool)
+
+
+def _run_and_compare(module, func_name, args, kw):
+    func = getattr(module, func_name)
+    exp = func(*args, **kw)
+    exp = exp if isinstance(exp, tuple | list) else (exp,)
+
+    got = quaxify(func)(*args, **kw)
+    got = got if isinstance(got, tuple | list) else (got,)
+
+    assert jtu.all(jtu.map(jnp.allclose, got, exp))
 
 
 @pytest.mark.parametrize(
@@ -446,16 +440,7 @@ xbool = jnp.array([True, False, True], dtype=bool)
 )
 def test_numpy_functions(func_name, args, kw):
     """Test lax vs qlax functions."""
-    func = getattr(jnp, func_name)
-    # Jax
-    exp = func(*args, **kw)
-    exp = exp if isinstance(exp, tuple | list) else (exp,)
-
-    # Quaxed
-    got = quaxify(func)(*args, **kw)
-    got = got if isinstance(got, tuple | list) else (got,)
-
-    assert jtu.all(jtu.map(jnp.allclose, got, exp))
+    _run_and_compare(jnp, func_name, args, kw)
 
 
 ###############################################################################
@@ -511,13 +496,4 @@ xN3 = jnp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float)
 )
 def test_linalg_functions(func_name, args, kw):
     """Test lax vs qlax functions."""
-    func = getattr(jnp.linalg, func_name)
-    # Jax
-    exp = func(*args, **kw)
-    exp = exp if isinstance(exp, tuple | list) else (exp,)
-
-    # Quaxed
-    got = quaxify(func)(*args, **kw)
-    got = got if isinstance(got, tuple | list) else (got,)
-
-    assert jtu.all(jtu.map(jnp.allclose, got, exp))
+    _run_and_compare(jnp.linalg, func_name, args, kw)

--- a/tests/unit/test_numpy/test_myarray.py
+++ b/tests/unit/test_numpy/test_myarray.py
@@ -4,38 +4,42 @@ import jax.numpy as jnp
 import jax.random as jr
 import jax.tree as jtu
 import pytest
-from packaging.version import Version
 
 import quax
-from quax._compat import JAX_VERSION
 
+from .._markers import (
+    mark_nomd,
+    mark_todo,
+    skip_removed_jax_0_10_0,
+    xfail_deprecated_jax_0_9_0,
+    xfail_quax58,
+)
 from ..myarray import is_myarray, MyArray, unwrap
 from ..test_lax.test_myarray import _unwrap_myarray
 
-
-xfail_quax58 = pytest.mark.xfail(
-    reason="https://github.com/patrick-kidger/quax/issues/58"
-)
-mark_todo = pytest.mark.skip("TODO")
-mark_nomd = pytest.mark.xfail(reason="Can't be supported with MD on primitives")
-skip_removed_jax_0_10_0 = pytest.mark.skipif(
-    JAX_VERSION >= Version("0.10"),
-    reason="removed in JAX v0.10.0",
-)
-xfail_deprecated_jax_0_9_0 = (
-    pytest.mark.xfail(
-        Version("0.9") <= JAX_VERSION < Version("0.10"),
-        raises=DeprecationWarning,
-        reason="deprecated in JAX v0.9.0",
-        strict=True,
-    ),
-    pytest.mark.filterwarnings("error::DeprecationWarning"),
-)
 
 x = MyArray(jnp.array([[1, 2], [3, 4]], dtype=float))
 y = MyArray(jnp.array([[5, 6], [7, 8]], dtype=float))
 xtrig = MyArray(jnp.array([[0.1, 0.2], [0.3, 0.4]], dtype=float))
 xbool = MyArray(jnp.array([True, False, True], dtype=bool))
+
+
+def _run_and_compare(module, func_name, args, kw, expect_myarray=None):
+    # Jax
+    func = getattr(module, func_name)
+    jax_args, jax_kw = jtu.map(unwrap, (args, kw), is_leaf=is_myarray)
+    exp = func(*jax_args, **jax_kw)
+    exp = exp if isinstance(exp, tuple | list) else (exp,)
+
+    # Quaxed
+    got = quax.quaxify(func)(*args, **kw)
+    got = got if isinstance(got, tuple | list) else (got,)
+    if expect_myarray is None:
+        got = jtu.map(unwrap, got, is_leaf=is_myarray)
+    else:
+        got = _unwrap_myarray(got, expect_myarray)
+
+    assert jtu.all(jtu.map(jnp.allclose, got, exp))
 
 
 @pytest.mark.parametrize(
@@ -502,18 +506,7 @@ xbool = MyArray(jnp.array([True, False, True], dtype=bool))
 )
 def test_numpy_functions(func_name, args, kw, expect_myarray):
     """Test lax vs qlax functions."""
-    # Jax
-    func = getattr(jnp, func_name)
-    jax_args, jax_kw = jtu.map(unwrap, (args, kw), is_leaf=is_myarray)
-    exp = func(*jax_args, **jax_kw)
-    exp = exp if isinstance(exp, tuple | list) else (exp,)
-
-    # Quaxed
-    got = quax.quaxify(func)(*args, **kw)
-    got = got if isinstance(got, tuple | list) else (got,)
-    got = _unwrap_myarray(got, expect_myarray)
-
-    assert jtu.all(jtu.map(jnp.allclose, got, exp))
+    _run_and_compare(jnp, func_name, args, kw, expect_myarray)
 
 
 # ###############################################################################
@@ -587,15 +580,4 @@ xN3 = MyArray(jnp.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float))
 )
 def test_linalg_functions(func_name, args, kw):
     """Test lax vs qlax functions."""
-    # Jax
-    func = getattr(jnp.linalg, func_name)
-    jax_args, jax_kw = jtu.map(unwrap, (args, kw), is_leaf=is_myarray)
-    exp = func(*jax_args, **jax_kw)
-    exp = exp if isinstance(exp, tuple | list) else (exp,)
-
-    # Quaxed
-    got = quax.quaxify(func)(*args, **kw)
-    got = got if isinstance(got, tuple | list) else (got,)
-    got = jtu.map(unwrap, got, is_leaf=is_myarray)
-
-    assert jtu.all(jtu.map(jnp.allclose, got, exp))
+    _run_and_compare(jnp.linalg, func_name, args, kw)

--- a/tests/usage/test_cond.py
+++ b/tests/usage/test_cond.py
@@ -19,16 +19,17 @@ def _outer_fn(a: jax.Array, b: jax.Array, c: jax.Array, pred: bool | jax.Array):
     return res
 
 
-def test_cond_basic():
+@pytest.mark.parametrize("wrap", [lambda f: f, jax.jit], ids=["eager", "jit"])
+def test_cond_basic(wrap):
     a = Unitful(jnp.asarray(1.0), {meters: 1})
     b = Unitful(jnp.asarray(2.0), {meters: 1})
     c = Unitful(jnp.asarray(10.0), {meters: 1})
 
-    res = quax.quaxify(_outer_fn)(a, b, c, False)
+    res = quax.quaxify(wrap(_outer_fn))(a, b, c, False)
     assert res.array == 11
     assert res.units == {meters: 1}
 
-    res = quax.quaxify(_outer_fn)(a, b, c, True)
+    res = quax.quaxify(wrap(_outer_fn))(a, b, c, True)
     assert res.array == 3
     assert res.units == {meters: 1}
 
@@ -89,20 +90,6 @@ def test_cond_switch():
 
     res = quax.quaxify(_outer_fn)(2, a, b, c)
     assert res.array == 13
-    assert res.units == {meters: 1}
-
-
-def test_cond_jit():
-    a = Unitful(jnp.asarray(1.0), {meters: 1})
-    b = Unitful(jnp.asarray(2.0), {meters: 1})
-    c = Unitful(jnp.asarray(10.0), {meters: 1})
-
-    res = quax.quaxify(jax.jit(_outer_fn))(a, b, c, False)
-    assert res.array == 11
-    assert res.units == {meters: 1}
-
-    res = quax.quaxify(jax.jit(_outer_fn))(a, b, c, True)
-    assert res.array == 3
     assert res.units == {meters: 1}
 
 

--- a/tests/usage/test_named.py
+++ b/tests/usage/test_named.py
@@ -1,3 +1,4 @@
+import operator
 from typing import cast
 
 import equinox as eqx
@@ -41,7 +42,10 @@ def test_add(getkey):
     assert out2 == true_out
 
 
-def test_add_axis_mismatch(getkey):
+@pytest.mark.parametrize(
+    "op", [operator.add, operator.mul, operator.sub], ids=["add", "mul", "sub"]
+)
+def test_add_axis_mismatch(getkey, op):
     # Elementwise ops combine the underlying arrays positionally, so adding
     # (A, B) to (B, A) is a name mismatch. The old set-based broadcast check
     # accepted it and silently computed the positional sum with mislabelled
@@ -52,13 +56,12 @@ def test_add_axis_mismatch(getkey):
     y_reversed = named.NamedArray(jr.normal(getkey(), (3, 3)), (B, A))
     y_aligned = named.NamedArray(jr.normal(getkey(), (3, 3)), (A, B))
 
-    for op in (lambda a, b: a + b, lambda a, b: a * b, lambda a, b: a - b):
-        # Reordered axes are rejected...
-        with pytest.raises(ValueError, match="Cannot broadcast named axes"):
-            quax.quaxify(op)(x, y_reversed)
-        # ...and aligned axes (A with A, B with B) combine fine.
-        out = quax.quaxify(op)(x, y_aligned)
-        assert out.axes == (A, B)
+    # Reordered axes are rejected...
+    with pytest.raises(ValueError, match="Cannot broadcast named axes"):
+        quax.quaxify(op)(x, y_reversed)
+    # ...and aligned axes (A with A, B with B) combine fine.
+    out = quax.quaxify(op)(x, y_aligned)
+    assert out.axes == (A, B)
 
 
 def test_matmul(getkey):

--- a/tests/usage/test_sparse.py
+++ b/tests/usage/test_sparse.py
@@ -100,16 +100,8 @@ def test_add_sparse(getkey):
 
 
 def test_mul(getkey):
-    data = jr.normal(getkey(), (2, 4))
-    indices0 = jnp.array([2, 0, 3])
-    indices1 = jnp.array([0, 0, 3])
-    indices2 = jnp.array([1, 0, 0])
-    indices3 = jnp.array([2, 0, 1])
-    indices_batch0 = jnp.stack([indices0, indices1, indices2, indices3])
-    indices_batch1 = jnp.stack([indices1, indices0, indices3, indices3])
-    indices = jnp.stack([indices_batch0, indices_batch1])
-    shape = (2, 5, 1, 4)
-    x = sparse.BCOO(data, indices, shape)
+    x = _make_sparse_example(getkey)
+    data, indices, shape = x.data, x.indices, x.shape
     y0 = 3
     y1 = jr.normal(getkey(), (5, 1, 4))
     y2 = jr.normal(getkey(), (2, 5, 1, 4))

--- a/tests/usage/test_while.py
+++ b/tests/usage/test_while.py
@@ -23,11 +23,12 @@ def _outer_fn(a: jax.Array, b: jax.Array, c: jax.Array):
     return res
 
 
-def test_while_basic():
+@pytest.mark.parametrize("wrap", [lambda f: f, jax.jit], ids=["eager", "jit"])
+def test_while_basic(wrap):
     a = Unitful(jnp.asarray(1.0), {meters: 1})
     b = Unitful(jnp.asarray(2.0), {meters: 1})
     c = Unitful(jnp.asarray(10.0), {meters: 1})
-    res = quax.quaxify(_outer_fn)(a, b, c)
+    res = quax.quaxify(wrap(_outer_fn))(a, b, c)
     assert res.array == 11
     assert res.units == {meters: 1}
 
@@ -38,15 +39,6 @@ def test_while_different_units():
     c = Unitful(jnp.asarray([10.0]), {kilograms: 1})
     with pytest.raises(Exception):
         quax.quaxify(_outer_fn)(a, b, c)
-
-
-def test_while_jit():
-    a = Unitful(jnp.asarray(1.0), {meters: 1})
-    b = Unitful(jnp.asarray(2.0), {meters: 1})
-    c = Unitful(jnp.asarray(10.0), {meters: 1})
-    res = quax.quaxify(jax.jit(_outer_fn))(a, b, c)
-    assert res.array == 11
-    assert res.units == {meters: 1}
 
 
 def test_while_vmap():

--- a/tests/usage/test_zero.py
+++ b/tests/usage/test_zero.py
@@ -40,54 +40,62 @@ def test_materialise():
     assert jnp.array_equal(out, jnp.zeros((3, 4), jnp.float32))
 
 
-def test_add():
+@pytest.mark.parametrize(
+    "add",
+    [quax.quaxify(lambda x, y: x + y), quax.quaxify(jnp.add)],
+    ids=["lambda", "jnp_add"],
+)
+def test_add(add):
     scalar_zero = zero.Zero((), jnp.float32)
     vector_zero = zero.Zero((2,), jnp.bool_)
     tensor_zero = zero.Zero((3, 3, 3), jnp.int32)
 
-    for add in (quax.quaxify(lambda x, y: x + y), quax.quaxify(jnp.add)):
-        assert tree_allclose(add(scalar_zero, 1), jnp.array(1.0))
-        assert eqx.tree_equal(add(scalar_zero, jnp.array(1)), jnp.array(1.0))
-        assert tree_allclose(add(1, scalar_zero), jnp.array(1.0))
-        assert eqx.tree_equal(add(jnp.array(1), scalar_zero), jnp.array(1.0))
+    assert tree_allclose(add(scalar_zero, 1), jnp.array(1.0))
+    assert eqx.tree_equal(add(scalar_zero, jnp.array(1)), jnp.array(1.0))
+    assert tree_allclose(add(1, scalar_zero), jnp.array(1.0))
+    assert eqx.tree_equal(add(jnp.array(1), scalar_zero), jnp.array(1.0))
 
-        assert tree_allclose(add(vector_zero, 1), jnp.array([1, 1]))
-        assert eqx.tree_equal(add(vector_zero, jnp.array(1)), jnp.array([1, 1]))
-        assert tree_allclose(add(1, vector_zero), jnp.array([1, 1]))
-        assert eqx.tree_equal(add(jnp.array(1), vector_zero), jnp.array([1, 1]))
+    assert tree_allclose(add(vector_zero, 1), jnp.array([1, 1]))
+    assert eqx.tree_equal(add(vector_zero, jnp.array(1)), jnp.array([1, 1]))
+    assert tree_allclose(add(1, vector_zero), jnp.array([1, 1]))
+    assert eqx.tree_equal(add(jnp.array(1), vector_zero), jnp.array([1, 1]))
 
-        assert tree_allclose(add(tensor_zero, 1), jnp.ones((3, 3, 3), jnp.int32))
-        assert eqx.tree_equal(
-            add(tensor_zero, jnp.array(1)), jnp.ones((3, 3, 3), jnp.int32)
-        )
-        assert tree_allclose(add(1, tensor_zero), jnp.ones((3, 3, 3), jnp.int32))
-        assert eqx.tree_equal(
-            add(jnp.array(1), tensor_zero), jnp.ones((3, 3, 3), jnp.int32)
-        )
+    assert tree_allclose(add(tensor_zero, 1), jnp.ones((3, 3, 3), jnp.int32))
+    assert eqx.tree_equal(
+        add(tensor_zero, jnp.array(1)), jnp.ones((3, 3, 3), jnp.int32)
+    )
+    assert tree_allclose(add(1, tensor_zero), jnp.ones((3, 3, 3), jnp.int32))
+    assert eqx.tree_equal(
+        add(jnp.array(1), tensor_zero), jnp.ones((3, 3, 3), jnp.int32)
+    )
 
 
-def test_mul():
+@pytest.mark.parametrize(
+    "mul",
+    [quax.quaxify(lambda x, y: x * y), quax.quaxify(jnp.multiply)],
+    ids=["lambda", "jnp_multiply"],
+)
+def test_mul(mul):
     # TODO: revisit this once we support weak types.
     scalar_zero = zero.Zero((), jnp.float32)
     in_vector_zero = zero.Zero((2,), jnp.bool_)
     out_vector_zero = zero.Zero((2,), jnp.int32)
     tensor_zero = zero.Zero((3, 3, 3), jnp.int32)
 
-    for mul in (quax.quaxify(lambda x, y: x * y), quax.quaxify(jnp.multiply)):
-        assert tree_allclose(mul(scalar_zero, 1), scalar_zero)
-        assert eqx.tree_equal(mul(scalar_zero, jnp.array(1)), scalar_zero)
-        assert tree_allclose(mul(1, scalar_zero), scalar_zero)
-        assert eqx.tree_equal(mul(jnp.array(1), scalar_zero), scalar_zero)
+    assert tree_allclose(mul(scalar_zero, 1), scalar_zero)
+    assert eqx.tree_equal(mul(scalar_zero, jnp.array(1)), scalar_zero)
+    assert tree_allclose(mul(1, scalar_zero), scalar_zero)
+    assert eqx.tree_equal(mul(jnp.array(1), scalar_zero), scalar_zero)
 
-        assert tree_allclose(mul(in_vector_zero, 1), out_vector_zero)
-        assert eqx.tree_equal(mul(in_vector_zero, jnp.array(1)), out_vector_zero)
-        assert tree_allclose(mul(1, in_vector_zero), out_vector_zero)
-        assert eqx.tree_equal(mul(jnp.array(1), in_vector_zero), out_vector_zero)
+    assert tree_allclose(mul(in_vector_zero, 1), out_vector_zero)
+    assert eqx.tree_equal(mul(in_vector_zero, jnp.array(1)), out_vector_zero)
+    assert tree_allclose(mul(1, in_vector_zero), out_vector_zero)
+    assert eqx.tree_equal(mul(jnp.array(1), in_vector_zero), out_vector_zero)
 
-        assert tree_allclose(mul(tensor_zero, 1), tensor_zero)
-        assert eqx.tree_equal(mul(tensor_zero, jnp.array(1)), tensor_zero)
-        assert tree_allclose(mul(1, tensor_zero), tensor_zero)
-        assert eqx.tree_equal(mul(jnp.array(1), tensor_zero), tensor_zero)
+    assert tree_allclose(mul(tensor_zero, 1), tensor_zero)
+    assert eqx.tree_equal(mul(tensor_zero, jnp.array(1)), tensor_zero)
+    assert tree_allclose(mul(1, tensor_zero), tensor_zero)
+    assert eqx.tree_equal(mul(jnp.array(1), tensor_zero), tensor_zero)
 
 
 @pytest.mark.skipif(not JAX_GE_0_10_0, reason="out_dtype kwarg requires JAX >= 0.10.0")
@@ -118,19 +126,19 @@ def test_mul_out_dtype():
     assert result.shape == (2,)
 
 
-def test_matmul(getkey):
-    for use_bias in (False, True):
-        linear = eqx.nn.Linear(2, 3, key=getkey(), use_bias=use_bias)
-        linear = eqx.tree_at(
-            lambda x: x.weight,
-            linear,
-            zero.Zero(linear.weight.shape, linear.weight.dtype),
-        )
-        out = quax.quaxify(linear)(jnp.ones(2))
-        if use_bias:
-            assert jnp.array_equal(out, linear.bias)
-        else:
-            assert eqx.tree_equal(out, zero.Zero((3,), jnp.float32))
+@pytest.mark.parametrize("use_bias", [False, True])
+def test_matmul(getkey, use_bias):
+    linear = eqx.nn.Linear(2, 3, key=getkey(), use_bias=use_bias)
+    linear = eqx.tree_at(
+        lambda x: x.weight,
+        linear,
+        zero.Zero(linear.weight.shape, linear.weight.dtype),
+    )
+    out = quax.quaxify(linear)(jnp.ones(2))
+    if use_bias:
+        assert jnp.array_equal(out, linear.bias)
+    else:
+        assert eqx.tree_equal(out, zero.Zero((3,), jnp.float32))
 
 
 def test_dynamic_update_slice(getkey):


### PR DESCRIPTION
## Summary
- Extract shared `pytest.mark` constants (`mark_todo`, `xfail_quax58`, `mark_nomd`, `skip_removed_jax_0_10_0`, `xfail_deprecated_jax_0_9_0`) that were redefined identically across `test_lax`/`test_numpy`'s jax_array/myarray test pairs into a new `tests/unit/_markers.py`, and dedupe each pair's near-identical test bodies into a shared `_run_and_compare` helper (also surfaced and fixed one small pre-existing inconsistency: `test_lax/test_myarray.py`'s linalg test used `jnp.array_equal` while its sibling used `jnp.allclose` — now explicit via a `cmp=` parameter instead of silent duplication).
- Merge 9 near-identical `TypedInt`/`TypedFloat`/`TypedComplex` tests in `test_jax_compat.py` into one parametrized test; drop redundant per-test `skipif` already covered by the module-level `pytestmark`.
- Add a shared `inner_add_one` fixture in `test_jit_quax_cache.py` for the repeated clear-cache + `jax.jit` setup.
- Extract repeated literal-array fixtures in `test_custom_vjp.py`, `test_custom_jvp.py`, and `test_aval_binds_primitive.py`; `test_sparse.py::test_mul` now reuses `_make_sparse_example` instead of retyping its literals.
- Collapse the basic/jit test pairs in `test_cond.py`/`test_while.py` into one test parametrized over `wrap` (left `test_scan.py`'s pair alone — it isn't a clean wrap-only difference).
- Convert manual internal loops to `@pytest.mark.parametrize` in `test_zero.py`/`test_named.py` for per-case failure isolation.
- `test_skill_examples.py` now reports pass/fail per doc code block instead of aborting the whole test at the first bad block, while preserving execution order/shared namespace across blocks.
- Collapse 4 identical `test_construction.py` benchmarks into one parametrized over constructor.
- Add a `bench` fixture to `tests/benchmark/conftest.py` (with a `jit=` flag) replacing hand-duplicated/hand-inlined `_bench` helpers across 4 benchmark files.

Deliberately **not** done: merging the giant `test_lax`/`test_numpy` jax_array vs myarray parametrize tables into one shared source. Several cases (e.g. `lax.select`'s boolean predicate, `place`'s mask built from `x.array`) show the myarray variant doing genuinely different per-case construction, not just "wrap the same value" — an automated merge would either lose that nuance or re-encode it as override metadata, which is more complexity than the duplication it removes.

## Test plan
- [x] `pytest tests/unit tests/usage tests/integration tests/test_doc_links.py tests/test_skill_examples.py` — 1089 passed, 137 skipped, 37 xfailed, 6 xpassed (same skip/xfail/xpass counts as pre-change baseline; passed count increased because former loop-body assertions now report as individual parametrized cases)
- [x] `pytest tests/benchmark/ --collect-only` — 130 collected, no errors
- [x] `ruff check` / `ruff format --check` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)