### PR TITLE
docs: explain autodiff and control flow, and the loop-carry trap

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -32,7 +32,7 @@ def setup(namespace):
 
 pytest_collect_file = Sybil(
     parsers=[PythonCodeBlockParser(), SkipParser()],
-    patterns=["README.md", "SKILL.md"],
+    patterns=["README.md", "SKILL.md", "autodiff.md", "control-flow.md"],
     excludes=["examples/*/README.md"],
     setup=setup,
 ).pytest()

--- a/docs/autodiff.md
+++ b/docs/autodiff.md
@@ -1,0 +1,82 @@
+# Autodiff
+
+Quax is a JAX transform, so it composes with the others. `jax.grad`,
+`jax.jvp`, `jax.vjp`, `jax.jit` and `jax.vmap` all work through a
+`quax.quaxify`, in either order, and nest.
+
+The part worth knowing is what comes *back*.
+
+## Cotangents keep your type
+
+Differentiate a quaxified function and the cotangent is an instance of your
+type, not a plain array. For a type that carries units, that means the
+gradient carries the derivative's units:
+
+```python
+import jax
+import jax.numpy as jnp
+import quax
+from quax.examples.unitful import meters, Unitful
+
+def area(x):
+    return x * x
+
+length = Unitful(jnp.asarray([2.0, 3.0]), meters)
+
+out = quax.quaxify(area)(length)
+print(out.units)  # {m: 2}
+
+grad = jax.grad(lambda x: quax.quaxify(area)(x).array.sum())(length)
+print(grad.units)  # {m: 1}
+```
+
+`d(m²)/dm` is in metres, and that is what arrives. Nothing in `area` mentions
+units; the rules registered on `Unitful` did the work in both directions.
+
+This falls out of how JAX cotangents work — they match the structure of the
+primal input — rather than being something Quax arranges specially. It does
+mean a rule author gets it for free, and that a `Value` with an invariant to
+enforce keeps enforcing it on the backward pass.
+
+## Custom derivative rules
+
+A function carrying its own derivative rule via `jax.custom_jvp` or
+`jax.custom_vjp` works under `quaxify`, forwards and backwards:
+
+```python
+@jax.custom_jvp
+def square(x):
+    return x * x
+
+@square.defjvp
+def square_jvp(primals, tangents):
+    (x,), (dx,) = primals, tangents
+    return x * x, 2 * x * dx
+
+print(quax.quaxify(square)(length).units)  # {m: 2}
+
+grad = jax.grad(lambda x: quax.quaxify(square)(x).array.sum())(length)
+print(grad.units)  # {m: 1}
+```
+
+`jax.custom_vjp` behaves the same way. This matters more than it first looks:
+custom derivative rules are how libraries express derivatives they know better
+than autodiff does, so supporting them is what lets Quax reach into those
+libraries at all. `equinox.internal.while_loop` is built on `custom_vjp`, and
+so, transitively, is every `diffrax` solve.
+
+Two constraints follow from the rules being *yours*:
+
+- The fwd and bwd rules run under the Quax trace, so they dispatch on your
+  type like any other code. A rule that only handles plain arrays will
+  materialise.
+- Structural decisions a fwd rule stashes for its bwd rule — a Python `bool`
+  used to pick a branch, say — stay Python values rather than becoming traced
+  arrays, so `if` on them still works.
+
+## What is not supported
+
+Forward-over-reverse and reverse-over-reverse compose as JAX does; nothing in
+Quax special-cases them. Where Quax stops being transparent is at a library's
+own scratch buffers, and inside loops whose carry changes shape or metadata —
+both covered in [Sharp bits](sharp-bits.md).

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -1,0 +1,67 @@
+# Control flow
+
+`jax.jit`, `lax.cond`, `lax.while_loop`, `lax.fori_loop` and `lax.scan` all
+work under `quax.quaxify`, and your type survives them:
+
+```python
+import jax
+import jax.numpy as jnp
+import quax
+from jax import lax
+from quax.examples.unitful import meters, Unitful
+
+length = Unitful(jnp.asarray([2.0, 3.0]), meters)
+
+square = quax.quaxify(jax.jit(lambda x: x * x))
+print(square(length).units)  # {m: 2}
+
+branch = quax.quaxify(lambda x: lax.cond(True, lambda: x * x, lambda: x * x))
+print(branch(length).units)  # {m: 2}
+```
+
+## How it works
+
+These primitives take a *jaxpr* rather than a callable — the body has already
+been traced by the time Quax sees it. So Quax cannot simply dispatch on it the
+way it dispatches on `mul_p`.
+
+Instead it re-traces: it runs the body through `quaxify` again, producing a new
+jaxpr that operates on your type's leaves, and rebinds the primitive with that.
+`lax.cond` gets this treatment per branch, `lax.scan` once for the body.
+
+Two consequences fall out of re-tracing, and both are visible from the outside.
+
+A `Value` that flattens to several arrays changes the number of operands the
+primitive takes, so Quax rebuilds the primitive's parameters to match. This is
+why a type with two array fields works in a `scan` carry at all.
+
+And the body is traced **once**, not once per iteration. That is where the
+sharp edge is.
+
+## The loop-carry trap
+
+A loop's carry must be stable — JAX enforces this, and rejects a body whose
+output type differs from its input. But a `Value`'s Python-level metadata is
+*static*: it does not appear in the JAX type at all. So a body that changes it
+looks perfectly stable to JAX, and the change is silently lost:
+
+```python
+def square_thrice(x):
+    return lax.fori_loop(0, 3, lambda i, c: c * c, x)
+
+out = quax.quaxify(square_thrice)(Unitful(jnp.asarray([2.0]), meters))
+print(out.array)  # [256.] -- correct, 2**8
+print(out.units)  # {m: 2}  -- wrong, should be {m: 8}
+```
+
+The number is right. The units are not: squaring three times should give
+`{m: 8}`, and the result claims `{m: 2}` — what one pass through the body
+produced. `lax.while_loop` and `lax.scan` mislabel the same way, differing only
+in which pass they happen to keep.
+
+`lax.cond` does not have this problem: its branches are traced separately and
+compared, so a disagreement is caught rather than absorbed.
+
+This is a real trap rather than a limitation to work around, so it is written
+up in full — with what to do about it — in
+[Sharp bits](sharp-bits.md#a-loop-carry-silently-keeps-the-metadata-it-started-with).

--- a/docs/sharp-bits.md
+++ b/docs/sharp-bits.md
@@ -50,6 +50,37 @@ the information was lost.
 If you want a type that survives these boundaries, implement `materialise` to
 return the dense array. If you want the boundary flagged, raise.
 
+## 🔪 A loop carry silently keeps the metadata it started with
+
+A `Value`'s Python-level metadata — units, a sparsity pattern, anything held in
+an `eqx.field(static=True)` — is invisible to JAX's type system. JAX enforces
+that a loop carry is type-stable, but it cannot see static metadata, so a body
+that *changes* it passes the check and the change is thrown away:
+
+```python
+def square_thrice(x):
+    return lax.fori_loop(0, 3, lambda i, c: c * c, x)
+
+out = quax.quaxify(square_thrice)(Unitful(jnp.asarray([2.0]), meters))
+print(out.array)  # [256.] -- right
+print(out.units)  # {m: 2}  -- wrong; three squarings is {m: 8}
+```
+
+The array is correct. The metadata describes one pass through the body, because
+that is how many times Quax traced it. `lax.while_loop` and `lax.scan` do the
+same thing, keeping a different pass; `lax.cond` does not, because its branches
+are traced separately and compared.
+
+This is the one failure on this page that is silently *wrong* rather than
+merely lossy, so it is worth knowing the shape of it: a loop body that changes
+your type's metadata is not something Quax can express, and it will not tell
+you so.
+
+Keep loop carries metadata-stable. If the metadata must change, do that outside
+the loop, or hoist it into the value itself where JAX can see it — an exponent
+stored as a traced array rather than a static field is checked like any other
+carry.
+
 ## 🔪 Implementing `aval()` correctly
 
 `aval()` must be a **pure method**: called on the same instance it must always return the same `jax.core.AbstractValue`. Quax caches the result at tracer-construction time for performance — if `aval()` could return different values over time, the cached result would become stale.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,8 @@ plugins:
 nav:
     - 'index.md'
     - 'faq.md'
+    - 'autodiff.md'
+    - 'control-flow.md'
     - 'sharp-bits.md'
     - API:
         - 'api/quax.md'

--- a/src/quax/_dispatch.py
+++ b/src/quax/_dispatch.py
@@ -31,7 +31,7 @@ def register(
         Used as decorator, and requires type annotations to perform multiple dispatch:
         ```python
         @quax.register(jax.lax.add_p)
-        def _(x: SomeValue, y: SomeValue):
+        def add_somevalue_somevalue(x: SomeValue, y: SomeValue):
             return ...  # some implementation
         ```
 


### PR DESCRIPTION
First pass of the Diátaxis docs audit: the content gaps. Structure comes separately.

## The gap

Grepping `docs/` for the features quax actually has:

```
custom_jvp     -- NOT MENTIONED IN DOCS --
custom_vjp     -- NOT MENTIONED IN DOCS --
scan           -- NOT MENTIONED IN DOCS --
```

`while` appeared once in passing; `cond` only as a caveat in Sharp bits. So a reader asking "can I `jax.grad` through this?" or "does `lax.scan` work?" had nowhere to look — despite both being supported, and autodiff having been the subject of #219, #222 and #223.

## Two explanation pages

**`docs/autodiff.md`** — what composes, and more usefully what comes *back*: cotangents arrive as your type, so a unit-carrying array differentiates to the derivative's units (`{m: 2}` forward, `{m: 1}` back). Then custom derivative rules, which is the part that matters structurally — supporting `custom_jvp`/`custom_vjp` is what lets quax reach into libraries built on them, `equinox.internal.while_loop` and so every diffrax solve.

**`docs/control-flow.md`** — the primitives that take a jaxpr rather than a callable, why that forces quax to re-trace the body, and the two consequences that are visible from outside: multi-leaf values changing the operand count, and the body being traced *once*.

Both are Diátaxis explanation — context and connections, no instruction. Both are executed by Sybil, and every printed value in them was checked against a real run rather than written from memory.

## A defect found while writing

A `Value`'s static metadata is invisible to JAX's type system. JAX enforces carry stability, but cannot see static fields — so a loop body that changes one passes the check and the change is silently discarded:

```
fori_loop, squaring three times:
  array [256.]   correct
  units {m: 2}   wrong -- {m: 8} is right
```

`while_loop` and `scan` mislabel the same way, keeping a different pass. `cond` is unaffected: its branches are traced separately and compared, so a disagreement is caught.

This is the only failure documented on that page that is silently *wrong* rather than lossy, so it gets its own Sharp bits entry with what to do instead. **Worth deciding separately whether quax should detect and raise here** rather than only documenting it — I have not attempted a fix.

## Also

`quax.register`'s own docstring still demonstrated `def _(x: SomeValue, ...)`, contradicting the naming convention #221 established repo-wide.

## Verification

- 1104 passed; the two new pages' examples run under Sybil
- printed outputs checked line by line against a real run
- `zensical build --clean` clean; the cross-page anchor verified against the generated slug
- ruff, pyright, taplo pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
