### PR TITLE
docs: add a How-to section

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -32,7 +32,13 @@ def setup(namespace):
 
 pytest_collect_file = Sybil(
     parsers=[PythonCodeBlockParser(), SkipParser()],
-    patterns=["README.md", "SKILL.md", "autodiff.md", "control-flow.md"],
+    patterns=[
+        "README.md",
+        "SKILL.md",
+        "autodiff.md",
+        "control-flow.md",
+        "how-to/*.md",
+    ],
     excludes=["examples/*/README.md"],
     setup=setup,
 ).pytest()

--- a/conftest.py
+++ b/conftest.py
@@ -38,6 +38,7 @@ pytest_collect_file = Sybil(
         "autodiff.md",
         "control-flow.md",
         "how-to/*.md",
+        "faq.md",
     ],
     excludes=["examples/*/README.md"],
     setup=setup,

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -33,6 +33,8 @@ When using `jax.jit` together with `quax.quaxify`, the recommended pattern is to
 import jax
 import quax
 
+fn = jax.numpy.add
+
 # Preferred: jit wraps the entire quaxified computation.
 jit_fn = jax.jit(quax.quaxify(fn))
 
@@ -58,3 +60,96 @@ vmap_fn = quax.quaxify(jax.vmap(fn))
 # Or equivalently:
 vmap_fn = jax.vmap(quax.quaxify(fn))
 ```
+
+## Should I write `grad(quaxify(f))` or `quaxify(grad(f))`?
+
+Both give the same numbers. They differ in what type the gradient comes back as,
+because whichever side of the `quaxify` boundary the differentiation happens on
+is the side that decides:
+
+```python
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import quax
+from jaxtyping import ArrayLike
+from typing import Any
+
+
+class Tracked(quax.ArrayValue):
+    array: jax.Array = eqx.field(converter=jnp.asarray)
+
+    def materialise(self):
+        return self.array
+
+    def aval(self):
+        return jax.typeof(self.array)
+
+
+@quax.register(jax.lax.mul_p)
+def mul_tracked(x: Tracked, y: Tracked | ArrayLike, **kw: Any) -> Tracked:
+    return Tracked(jax.lax.mul_p.bind(x.array, getattr(y, "array", y), **kw))
+
+
+def square_sum(z):
+    return jnp.sum(z * z)
+
+
+t = Tracked(jnp.asarray([2.0, 3.0]))
+
+print(type(jax.grad(quax.quaxify(square_sum))(t)).__name__)  # Tracked
+print(type(quax.quaxify(jax.grad(square_sum))(t)).__name__)  # ArrayImpl
+```
+
+Put `quaxify` on the inside when you want the gradient to keep your type — the
+cotangent then matches the primal you passed in. See
+[Autodiff](autodiff.md) for what that gives you.
+
+`jit` is not like this: both orderings return the same thing, and the
+recommendation above is about compilation, not types.
+
+## Why does `jnp.zeros_like(my_value)` give me a plain array?
+
+Because nothing was dispatched on. The `*_like` functions read a shape and a
+dtype off their argument and then allocate a fresh array; your value is never an
+operand of an operation, so there is no rule for Quax to find:
+
+```python
+print(type(quax.quaxify(jnp.zeros_like)(t)).__name__)  # ArrayImpl
+```
+
+This is the same mechanism as a library allocating its own scratch buffers, and
+[Sharp bits](sharp-bits.md) covers what follows from it. If you need a zero of
+your own type, construct it directly rather than deriving it.
+
+## Can I call a method on my `Value`?
+
+Only across a `quaxify` boundary. A method body is ordinary code, so it needs a
+trace installed before its operations can dispatch — outside one, the operators
+have nothing to hook into:
+
+```python
+class WithMethod(quax.ArrayValue):
+    array: jax.Array = eqx.field(converter=jnp.asarray)
+
+    def materialise(self):
+        return self.array
+
+    def aval(self):
+        return jax.typeof(self.array)
+
+    def doubled(self):
+        return self * 2.0
+
+
+try:
+    WithMethod(jnp.ones(2)).doubled()
+except TypeError as e:
+    print(e)  # unsupported operand type(s) for *: 'WithMethod' and 'float'
+
+quax.quaxify(WithMethod.doubled)(WithMethod(jnp.ones(2)))  # works
+```
+
+Quaxify the method as you would any other function. `quax.quaxify(Type.method)`
+takes the instance as its first argument, so it behaves like the unbound
+function it is.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -129,15 +129,7 @@ trace installed before its operations can dispatch — outside one, the operator
 have nothing to hook into:
 
 ```python
-class WithMethod(quax.ArrayValue):
-    array: jax.Array = eqx.field(converter=jnp.asarray)
-
-    def materialise(self):
-        return self.array
-
-    def aval(self):
-        return jax.typeof(self.array)
-
+class WithMethod(Tracked):
     def doubled(self):
         return self * 2.0
 

--- a/docs/how-to/quaxify-part-of-a-function.md
+++ b/docs/how-to/quaxify-part-of-a-function.md
@@ -10,48 +10,11 @@ shape: one entry for the function, one tuple for the positional arguments, one
 dict for the keyword arguments.
 
 ```python
-import equinox as eqx
-import jax
 import jax.numpy as jnp
 import quax
-from jaxtyping import ArrayLike
-from typing import Any
+from quax.examples.unitful import Unitful, meters, seconds
 
 
-class Meters(quax.ArrayValue):
-    array: jax.Array = eqx.field(converter=jnp.asarray)
-
-    def materialise(self):
-        return self.array
-
-    def aval(self):
-        return jax.typeof(self.array)
-
-
-class Seconds(quax.ArrayValue):
-    array: jax.Array = eqx.field(converter=jnp.asarray)
-
-    def materialise(self):
-        return self.array
-
-    def aval(self):
-        return jax.typeof(self.array)
-
-
-@quax.register(jax.lax.mul_p)
-def mul_meters_arraylike(x: Meters, y: ArrayLike, **kw: Any) -> Meters:
-    return Meters(jax.lax.mul_p.bind(x.array, y, **kw))
-
-
-@quax.register(jax.lax.mul_p)
-def mul_seconds_arraylike(x: Seconds, y: ArrayLike, **kw: Any) -> Seconds:
-    return Seconds(jax.lax.mul_p.bind(x.array, y, **kw))
-```
-
-Now quaxify the outer function for `Meters` only, and let `Seconds` reach the
-inner one:
-
-```python
 def inner(s):
     return s * 2.0
 
@@ -64,22 +27,15 @@ def outer(m, s):
 filter_spec = (False, (True, False), {})  # (fn, args, kwargs)
 
 m_out, s_out = quax.quaxify(outer, filter_spec=filter_spec)(
-    Meters(jnp.ones(2)), Seconds(jnp.ones(2))
+    Unitful(jnp.ones(2), meters), Unitful(jnp.ones(2), seconds)
 )
-print(type(m_out).__name__, m_out.array)  # Meters [3. 3.]
-print(type(s_out).__name__, s_out.array)  # Seconds [2. 2.]
+print(m_out.array, m_out.units)  # [3. 3.] {m: 1}
+print(s_out.array, s_out.units)  # [2. 2.] {s: 1}
 ```
 
-`False` at a position means "leave this alone"; `True` means "quaxify it". The
-function itself is usually `False` — set it `True` only if the callable carries
-`Value`s you want handled, such as a model whose weights are your type.
+`False` at a position means "leave this alone"; `True` means "quaxify it".
 
-## When to reach for this
-
-Mostly when two libraries' types would otherwise meet in one dispatch and you
-would be forced to
+Reach for this when two libraries' types would otherwise meet in one dispatch,
+and you would be forced to
 [write a rule for the combination](resolve-an-ambiguous-rule.md). Splitting the
 quaxifies keeps each type's rules owned by the project that defines them.
-
-If you only want a plain array left alone, you do not need `filter_spec` — pass
-it as a plain array and it stays one.

--- a/docs/how-to/quaxify-part-of-a-function.md
+++ b/docs/how-to/quaxify-part-of-a-function.md
@@ -1,0 +1,85 @@
+# Quaxify only some arguments
+
+By default `quax.quaxify` takes every `Value` you pass and handles it. Sometimes
+you want one to travel *through* untouched — most often so it reaches a nested
+`quax.quaxify` that knows what to do with it, rather than being resolved by the
+outer one.
+
+Pass a `filter_spec`. It partitions `(fn, args, kwargs)`, so the spec has that
+shape: one entry for the function, one tuple for the positional arguments, one
+dict for the keyword arguments.
+
+```python
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import quax
+from jaxtyping import ArrayLike
+from typing import Any
+
+
+class Meters(quax.ArrayValue):
+    array: jax.Array = eqx.field(converter=jnp.asarray)
+
+    def materialise(self):
+        return self.array
+
+    def aval(self):
+        return jax.typeof(self.array)
+
+
+class Seconds(quax.ArrayValue):
+    array: jax.Array = eqx.field(converter=jnp.asarray)
+
+    def materialise(self):
+        return self.array
+
+    def aval(self):
+        return jax.typeof(self.array)
+
+
+@quax.register(jax.lax.mul_p)
+def mul_meters_arraylike(x: Meters, y: ArrayLike, **kw: Any) -> Meters:
+    return Meters(jax.lax.mul_p.bind(x.array, y, **kw))
+
+
+@quax.register(jax.lax.mul_p)
+def mul_seconds_arraylike(x: Seconds, y: ArrayLike, **kw: Any) -> Seconds:
+    return Seconds(jax.lax.mul_p.bind(x.array, y, **kw))
+```
+
+Now quaxify the outer function for `Meters` only, and let `Seconds` reach the
+inner one:
+
+```python
+def inner(s):
+    return s * 2.0
+
+
+def outer(m, s):
+    # `s` arrives here untouched, so the nested quaxify is what handles it
+    return m * 3.0, quax.quaxify(inner)(s)
+
+
+filter_spec = (False, (True, False), {})  # (fn, args, kwargs)
+
+m_out, s_out = quax.quaxify(outer, filter_spec=filter_spec)(
+    Meters(jnp.ones(2)), Seconds(jnp.ones(2))
+)
+print(type(m_out).__name__, m_out.array)  # Meters [3. 3.]
+print(type(s_out).__name__, s_out.array)  # Seconds [2. 2.]
+```
+
+`False` at a position means "leave this alone"; `True` means "quaxify it". The
+function itself is usually `False` — set it `True` only if the callable carries
+`Value`s you want handled, such as a model whose weights are your type.
+
+## When to reach for this
+
+Mostly when two libraries' types would otherwise meet in one dispatch and you
+would be forced to
+[write a rule for the combination](resolve-an-ambiguous-rule.md). Splitting the
+quaxifies keeps each type's rules owned by the project that defines them.
+
+If you only want a plain array left alone, you do not need `filter_spec` — pass
+it as a plain array and it stays one.

--- a/docs/how-to/resolve-an-ambiguous-rule.md
+++ b/docs/how-to/resolve-an-ambiguous-rule.md
@@ -1,0 +1,77 @@
+# Resolve an ambiguous rule
+
+You called a quaxified function and plum could not decide which of your rules
+to use:
+
+```
+AmbiguousLookupError: `mul_dispatcher(Meters(array=f32[3]), Meters(array=f32[3]))`
+is ambiguous.
+```
+
+Two rules match the call and neither is more specific than the other. The usual
+shape is a pair written for mixed operands, meeting a call where *both* operands
+are yours:
+
+```python
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import quax
+from jaxtyping import ArrayLike
+from typing import Any
+
+
+class Meters(quax.ArrayValue):
+    array: jax.Array = eqx.field(converter=jnp.asarray)
+
+    def materialise(self):
+        return self.array
+
+    def aval(self):
+        return jax.typeof(self.array)
+
+
+@quax.register(jax.lax.mul_p)
+def mul_meters_any(x: Meters, y: Meters | ArrayLike, **kw: Any) -> Meters:
+    return Meters(jax.lax.mul_p.bind(x.array, getattr(y, "array", y), **kw))
+
+
+@quax.register(jax.lax.mul_p)
+def mul_any_meters(x: Meters | ArrayLike, y: Meters, **kw: Any) -> Meters:
+    return Meters(jax.lax.mul_p.bind(getattr(x, "array", x), y.array, **kw))
+```
+
+`Meters * Meters` matches both, equally well.
+
+## If you own both rules
+
+Add the specific rule and give it a higher precedence. Dispatch then has a
+single best answer rather than a tie:
+
+```python
+@quax.register(jax.lax.mul_p, precedence=1)
+def mul_meters_meters(x: Meters, y: Meters, **kw: Any) -> Meters:
+    return Meters(jax.lax.mul_p.bind(x.array, y.array, **kw))
+
+
+out = quax.quaxify(lambda a, b: a * b)(Meters(jnp.full(3, 2.0)), Meters(jnp.full(3, 3.0)))
+print(out.array)  # [6. 6. 6.]
+```
+
+Write the rule you actually want for that combination — the precedence only
+breaks the tie, it does not choose behaviour for you.
+
+## If the clash is between two libraries
+
+Do not register a rule for the combination. You would be deciding, on behalf of
+two projects you do not own, what their types mean together — and the answer
+would apply process-wide to everyone who imports you.
+
+Reach for [nested quaxifies](quaxify-part-of-a-function.md) instead: quaxify the
+outer call for one type, and let the other reach its own `quax.quaxify` further
+in.
+
+## See also
+
+The [advanced tutorial](../examples/redispatch.ipynb) works through why the
+ambiguity arises, if you want the reasoning rather than the fix.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,9 @@ nav:
     - 'autodiff.md'
     - 'control-flow.md'
     - 'sharp-bits.md'
+    - How-to:
+        - 'how-to/resolve-an-ambiguous-rule.md'
+        - 'how-to/quaxify-part-of-a-function.md'
     - API:
         - 'api/quax.md'
         - 'api/lora.md'


### PR DESCRIPTION
Second pass of the Diátaxis audit: the missing mode.

## The gap

Diátaxis has four modes, and quax had three. Task-oriented content existed but was filed where someone *at work* will not look:

| Task | Currently lives in |
|---|---|
| resolving an `AmbiguousLookupError` | section headings inside `redispatch.ipynb`, an **advanced tutorial** |
| quaxifying only some arguments | the `quaxify` docstring only |

Tutorials serve a user *at study* on a carefully-managed path; how-to guides serve one *at work* who already knows what they want. Someone staring at an `AmbiguousLookupError` is the second, and was being handed the first.

## Two guides

**[Resolve an ambiguous rule](docs/how-to/resolve-an-ambiguous-rule.md)** — starts from the error text, reproduces the shape that causes it (a pair of mixed-operand rules meeting a call where both operands are yours), then splits on ownership:

- you own both rules → add the specific one with `precedence=1`
- the clash is between two libraries → *don't* register a rule for the combination, because you would be deciding on their behalf, process-wide, for everyone who imports you

That second half is the part the tutorial's "Solution 1 / Solution 2" framing doesn't make load-bearing, and it is the one with consequences.

**[Quaxify only some arguments](docs/how-to/quaxify-part-of-a-function.md)** — what `filter_spec` is for. The docstring says it partitions `(fn, args, kwargs)` but never shows the shape; the working spec is `(False, (True, False), {})` and that is easy to get wrong. Worked through with the case it exists for: passing a `Value` through untouched so a nested `quaxify` handles it.

## Verified, not asserted

Both pages are executed by Sybil, and I checked the printed values against a real run rather than writing them from memory:

```
Meters [3. 3.]     Seconds [2. 2.]     [6. 6. 6.]
```

I also checked they do not pollute quax's process-global registry: the rules dispatch on page-local classes, so they cannot match anything else, and the full suite is unchanged at **1116 passed** (+4 for the new blocks).

`jax.core.get_aval` was removed in JAX 0.10, so the examples use `jax.typeof`, which I confirmed exists across the whole supported range including the 0.7.2 floor.

## Left alone

`redispatch.ipynb` keeps its treatment — explaining *why* the ambiguity arises is a different job from telling you what to type, and Diátaxis is explicit that the same topic can appear in more than one mode.

## Still outstanding from the audit

`docs/faq.md`'s "Best practices with `jit` and `vmap`" is how-to content wearing a FAQ hat. Moving it here would empty `faq.md` entirely, which deletes a page people may link to — worth a decision rather than a silent move, so I have not touched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
