### PR TITLE
Backport PR #233 on branch versions/v0.4.x (🐛 fix(loops): require a loop carry's structure to settle)

### DIFF
--- a/src/quax/_primitives.py
+++ b/src/quax/_primitives.py
@@ -3,7 +3,7 @@
 __all__ = ()
 
 import weakref
-from typing import Any, no_type_check
+from typing import Any, Final, no_type_check
 
 import jax
 import jax._src.core as core
@@ -14,7 +14,7 @@ from jaxtyping import ArrayLike
 from ._compat import is_early_inline, jit_p, scan_bind_params, unpack_scan_args
 from ._dispatch import register
 from ._quaxify import _Quaxify, quaxify
-from ._values import _make_cache_finalizer, ArrayValue
+from ._values import _is_value, _make_cache_finalizer, ArrayValue
 
 
 # Cache for jit_quax: maps (id(jaxpr), treedef) -> (jaxpr_wref, jitted_fn).
@@ -88,6 +88,58 @@ def jit_quax(
 _while_quax_cache: dict[tuple, tuple] = {}
 
 
+# One retrace settles a wrapper change; anything still moving after that is not
+# a structure a single traced body can represent.
+_MAX_CARRY_RETRACES: Final = 3
+
+_SHARP_BITS_URL: Final = "https://nstarman.github.io/quax/sharp-bits/"
+
+_CARRY_METADATA_CHANGED: Final = (
+    "`{primitive}` carry changed structure: the body was given\n"
+    "    {before}\n"
+    "and returned\n"
+    "    {after}\n"
+    "A carry must look the same every iteration, and for a `quax.Value` that "
+    f"includes its metadata -- see {_SHARP_BITS_URL}"
+)
+
+_CARRY_DID_NOT_SETTLE: Final = (
+    "`lax.while_loop` carry structure did not settle after {retraces} traces "
+    f"of the body -- see {_SHARP_BITS_URL}"
+)
+
+_CARRY_LEAF_COUNT_CHANGED: Final = (
+    "`lax.while_loop` carry changed its number of arrays inside the body, so "
+    "it cannot be bound against the initial carry."
+)
+
+
+def _check_carry_stable(before: Any, after: Any, primitive: str) -> None:
+    """Reject a loop body that changes a carried `Value`'s metadata.
+
+    A slot that gains or loses its `Value` wrapper is not this: materialising or
+    promoting leaves an honest plain array, and the caller settles it by
+    retracing. Only a slot that is a `Value` on both sides, with different
+    metadata, is unrepresentable -- so compare slot by slot.
+    """
+    before_leaves = jtu.tree_leaves(before, is_leaf=_is_value)
+    after_leaves = jtu.tree_leaves(after, is_leaf=_is_value)
+    if len(before_leaves) != len(after_leaves):
+        # A different count is a shape-level change; leave it to JAX to report.
+        return
+    for b, a in zip(before_leaves, after_leaves):
+        if not (_is_value(b) and _is_value(a)):
+            continue
+        b_treedef = jtu.tree_structure(b)
+        a_treedef = jtu.tree_structure(a)
+        if b_treedef == a_treedef:
+            continue
+        msg = _CARRY_METADATA_CHANGED.format(
+            primitive=primitive, before=b_treedef, after=a_treedef
+        )
+        raise TypeError(msg)
+
+
 @register(jax.lax.while_p)
 def while_quax(
     *args: ArrayValue | ArrayLike,
@@ -108,21 +160,39 @@ def while_quax(
     key = (id(cond_jaxpr), id(body_jaxpr), val_treedef)
     entry = _while_quax_cache.get(key)
     if entry is None:
-        quax_cond_fn = quaxify(jexc.jaxpr_as_fun(cond_jaxpr))
-        quax_cond_jaxpr = jax.make_jaxpr(quax_cond_fn)(*cond_consts, *init_vals)
         quax_body_fn = quaxify(jexc.jaxpr_as_fun(body_jaxpr))
-        quax_body_jaxpr = jax.make_jaxpr(quax_body_fn)(*body_consts, *init_vals)
+        # Trace to a fixed point: a wrapper change settles after one more pass,
+        # and what settles is what every later iteration sees. Metadata never
+        # settles, which `_check_carry_stable` rejects outright.
+        vals = tuple(init_vals)
+        for _ in range(_MAX_CARRY_RETRACES):
+            quax_body_jaxpr, body_out = jax.make_jaxpr(quax_body_fn, return_shape=True)(
+                *body_consts, *vals
+            )
+            _check_carry_stable(vals, body_out, "lax.while_loop")
+            if jtu.tree_structure(vals) == jtu.tree_structure(tuple(body_out)):
+                break
+            vals = tuple(body_out)
+        else:
+            msg = _CARRY_DID_NOT_SETTLE.format(retraces=_MAX_CARRY_RETRACES)
+            raise TypeError(msg)
+        if len(jtu.tree_leaves(vals)) != len(init_val_leaves):
+            raise TypeError(_CARRY_LEAF_COUNT_CHANGED)
+        # The condition sees the settled carry too.
+        quax_cond_fn = quaxify(jexc.jaxpr_as_fun(cond_jaxpr))
+        quax_cond_jaxpr = jax.make_jaxpr(quax_cond_fn)(*cond_consts, *vals)
+        out_treedef = jtu.tree_structure(vals)
         fin = _make_cache_finalizer(_while_quax_cache, key)
         entry = (
             weakref.ref(cond_jaxpr, fin),
             weakref.ref(body_jaxpr, fin),
             quax_cond_jaxpr,
             quax_body_jaxpr,
-            val_treedef,
+            out_treedef,
         )
         _while_quax_cache[key] = entry
     else:
-        _, _, quax_cond_jaxpr, quax_body_jaxpr, val_treedef = entry
+        _, _, quax_cond_jaxpr, quax_body_jaxpr, out_treedef = entry
 
     out_val = jax.lax.while_p.bind(
         *cond_leaves,
@@ -133,7 +203,7 @@ def while_quax(
         body_nconsts=body_nconsts,
         body_jaxpr=quax_body_jaxpr,
     )
-    result = jtu.tree_unflatten(val_treedef, out_val)
+    result = jtu.tree_unflatten(out_treedef, out_val)
     return result
 
 
@@ -224,7 +294,9 @@ def scan_quax(*args: ArrayValue | ArrayLike, jaxpr, **kwargs: Any) -> Any:
             consts = jtu.tree_unflatten(c_tree, flat[:nc])
             carry = jtu.tree_unflatten(v_tree, flat[nc : nc + nv])
             xs = jtu.tree_unflatten(x_tree, flat[nc + nv :])
-            return quaxify(fn)(*consts, *carry, *xs)
+            out = quaxify(fn)(*consts, *carry, *xs)
+            _check_carry_stable(carry, out[: len(carry)], "lax.scan")
+            return out
 
         quax_jaxpr, out_shape = jax.make_jaxpr(quax_fn, return_shape=True)(*trace_in)
         out_tree = jtu.tree_structure(out_shape)

--- a/tests/unit/myarray.py
+++ b/tests/unit/myarray.py
@@ -16,6 +16,26 @@ from quax._compat import JAX_GE_0_10_1, JAX_GE_0_11_0, JAX_VERSION, typeof
 
 
 @final
+class DenseArray(quax.ArrayValue):
+    """A :class:`quax.ArrayValue` that materialises freely.
+
+    :class:`MyArray` refuses to materialise, so it cannot exercise any path
+    that falls back to it. This one can, and behaves like most real
+    ``ArrayValue`` types in that respect.
+    """
+
+    array: jax.Array = eqx.field(converter=jnp.asarray)
+
+    def materialise(self) -> jax.Array:
+        """Convert to a JAX array."""
+        return self.array
+
+    def aval(self) -> jax.core.ShapedArray:
+        """Return the ShapedArray."""
+        return typeof(self.array)
+
+
+@final
 class MyArray(quax.ArrayValue):
     """A :class:`quax.ArrayValue` that is dense.
 

--- a/tests/usage/test_loop_carry.py
+++ b/tests/usage/test_loop_carry.py
@@ -1,0 +1,94 @@
+"""A loop carry's structure must settle.
+
+A `Value`'s metadata lives in its pytree structure rather than its aval, so
+JAX's carry-stability check cannot see it. A body that changes it used to pass
+that check and have the change dropped, returning a correct array wearing the
+wrong units.
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+from jax import lax
+
+import quax
+from quax.examples.unitful import meters, Unitful
+
+from ..unit.myarray import DenseArray
+
+
+def _while_squares(x):
+    return lax.while_loop(
+        lambda c: c[0] < 3, lambda c: (c[0] + 1, c[1] * c[1]), (0, x)
+    )[1]
+
+
+def _fori_squares(x):
+    return lax.fori_loop(0, 3, lambda i, c: c * c, x)
+
+
+def _scan_squares(x):
+    return lax.scan(lambda c, _: (c * c, None), x, None, length=2)[0]
+
+
+@pytest.mark.parametrize(
+    "fn", [_while_squares, _fori_squares, _scan_squares], ids=["while", "fori", "scan"]
+)
+def test_changing_carry_metadata_raises(fn):
+    """Squaring takes the units somewhere new on every iteration."""
+    x = Unitful(jnp.asarray([2.0]), meters)
+
+    with pytest.raises(TypeError, match="carry changed structure"):
+        quax.quaxify(fn)(x)
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        lambda x: lax.while_loop(
+            lambda c: c[0] < 3, lambda c: (c[0] + 1, c[1] + c[1]), (0, x)
+        )[1],
+        lambda x: lax.fori_loop(0, 3, lambda i, c: c + c, x),
+        lambda x: lax.scan(lambda c, _: (c + c, None), x, None, length=2)[0],
+    ],
+    ids=["while", "fori", "scan"],
+)
+def test_stable_carry_metadata_still_runs(fn):
+    """Doubling keeps the units, so the loop is representable."""
+    x = Unitful(jnp.asarray([2.0]), meters)
+
+    out = quax.quaxify(fn)(x)
+
+    assert isinstance(out, Unitful)
+    assert out.units == {meters: 1}
+
+
+def test_materialising_carry_is_not_an_error():
+    """Losing the wrapper is the documented fallback, not the failure above."""
+
+    # `DenseArray` has no registered rules, so `c + x` materialises it.
+    def f(carry, xs):
+        return lax.scan(lambda c, x: (c + x, None), carry, xs)[0]
+
+    out = quax.quaxify(jax.jit(f))(DenseArray(jnp.asarray(1.0)), jnp.arange(3.0))
+
+    assert not isinstance(out, quax.ArrayValue)
+    assert jnp.allclose(out, 1.0 + 0.0 + 1.0 + 2.0)
+
+
+def test_materialised_while_carry_is_not_rewrapped():
+    """`while_loop` labels its result from the settled body, not the input.
+
+    It used to unflatten with the input treedef, so a materialised carry came
+    back as the `Value` it no longer was.
+    """
+
+    def loop(x):
+        return lax.while_loop(
+            lambda c: c[0] < 3, lambda c: (c[0] + 1, c[1] + 1.0), (0, x)
+        )[1]
+
+    out = quax.quaxify(jax.jit(loop))(DenseArray(jnp.asarray([1.0])))
+
+    assert not isinstance(out, quax.ArrayValue)
+    assert jnp.allclose(out, 4.0)


### PR DESCRIPTION
Manual backport of #233 to `versions/v0.4.x`. The automatic backport conflicted.

## The fix, unchanged

A loop carry must be stable, and JAX enforces that — but only over what its type system can see. A `Value`'s metadata lives in its pytree *structure* rather than its aval, so a body that changed it passed JAX's check and had the change dropped:

```
fori_loop squaring three times from metres
  array [256.]  correct
  units {m: 2}  wrong -- {m: 8} is right
```

`while_quax` compounded it, unflattening the result with the **input** treedef, so a carry the body materialised away came back re-wrapped as the `Value` it no longer was.

Both come from one traced pass standing for every iteration, so the carry is traced to a fixed point instead. A wrapper change settles after one more pass, and that structure is what later iterations see. Metadata never settles (`{m: 1}`, `{m: 2}`, `{m: 4}`) and is refused. `scan` already labelled from its body, and `cond` already compared branches.

`src/quax/_primitives.py` here is byte-identical to `main` apart from `cond_quax`, which belongs to the unbackported #222 and is untouched.

## What the conflicts were, and how each was resolved

**Dropped — `docs/control-flow.md`, `docs/sharp-bits.md`.** Both pages come from #232, which is not on this branch. #233 folded a docs correction in because #232 had already described this failure as silent; with neither page here, there is no text to correct.

**Dropped — `tests/integration/test_diffrax_unitful.py`.** There is no `tests/integration/` on this branch. The `scatter_p` / `select_n_p` rules #233 added there exist only to keep that diffrax path tracing under the new check.

**Added — `_is_value` to the `._values` import in `_primitives.py`.** It arrived on `main` with #222; `_check_carry_stable` needs it, and the cherry-pick did not touch the import line.

**Added — the `DenseArray` helper in `tests/unit/myarray.py`,** verbatim from `main`. Same reason: it arrived with #222, and the two materialise tests need a value with no registered rules. `MyArray` refuses to materialise, so it cannot stand in.

## Tests

`tests/usage/test_loop_carry.py` came across verbatim — parametrized over `while_loop` / `fori_loop` / `scan`:

- a body that changes units raises `TypeError`
- a body that keeps them still runs and returns `{m: 1}`
- a body that materialises is explicitly *not* an error
- `while_loop` labels its result from the settled body, not the input

## Verification

1065 passed, 134 skipped, 37 xfailed. `ruff check` and `ruff format` clean; pyright 1.1.410 reports 0 errors on `src`.

Remember to remove the `Still Needs Manual Backport` label from #233 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
