### PR TITLE
docs: cut what the new pages say twice

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -40,7 +40,6 @@ pytest_collect_file = Sybil(
         "how-to/*.md",
         "tutorials/*.md",
         "how-quaxify-works.md",
-        "api/unitful.md",
         "faq.md",
     ],
     excludes=["examples/*/README.md"],

--- a/docs/api/unitful.md
+++ b/docs/api/unitful.md
@@ -4,17 +4,6 @@ A worked example of a `quax.Value` that carries metadata and refuses to give it 
 an array tagged with physical units. It is the type most of these docs use for
 demonstrations, because unit errors are easy to recognise as errors.
 
-```python
-import jax.numpy as jnp
-import quax
-from quax.examples.unitful import meters, seconds, Unitful
-
-distance = Unitful(jnp.asarray(100.0), meters)
-time = Unitful(jnp.asarray(9.58), seconds)
-speed = quax.quaxify(lambda d, t: d * t**-1)(distance, time)
-print(speed.units)  # {m: 1, s: -1}
-```
-
 Rules are registered for `add`, `mul`, `integer_pow`, `lt`, `broadcast_in_dim`,
 `copy` and `select_n` -- enough to differentiate through, and to run a `lax` loop
 or a `diffrax` solve. Anything else raises rather than dropping the units.

--- a/docs/how-quaxify-works.md
+++ b/docs/how-quaxify-works.md
@@ -42,7 +42,6 @@ from jaxtyping import ArrayLike
 
 class Tagged(quax.ArrayValue):
     array: jax.Array = eqx.field(converter=jnp.asarray)
-    tag: str = eqx.field(static=True)
 
     def aval(self):
         return jax.typeof(self.array)
@@ -52,7 +51,7 @@ class Tagged(quax.ArrayValue):
         return self.array
 
 
-x = Tagged(jnp.asarray([1.0, 2.0]), "a")
+x = Tagged(jnp.asarray([1.0, 2.0]))
 
 # No rule for add_p, so case 3: materialise and run plain JAX.
 print(type(quax.quaxify(lambda v: v + 1.0)(x)).__name__)  # materialised
@@ -61,10 +60,10 @@ print(type(quax.quaxify(lambda v: v + 1.0)(x)).__name__)  # materialised
 
 @quax.register(jax.lax.mul_p)
 def mul_tagged_array_like(a: Tagged, b: ArrayLike, **kw: Any) -> Tagged:
-    return Tagged(jax.lax.mul_p.bind(a.array, b, **kw), a.tag)
+    return Tagged(jax.lax.mul_p.bind(a.array, b, **kw))
 
 
-# Now case 1: a rule matches, and the tag survives.
+# Now case 1: a rule matches, and the type survives.
 print(type(quax.quaxify(lambda v: v * 2.0)(x)).__name__)  # Tagged
 ```
 

--- a/docs/how-to/combine-with-jit-and-vmap.md
+++ b/docs/how-to/combine-with-jit-and-vmap.md
@@ -26,22 +26,10 @@ measured about 15× faster on the machine these docs were written on. Treat the
 shape of that rather than the number: it is fixed overhead, so the gap widens as
 arrays get smaller and closes as they get larger.
 
-`jit` further out still counts as outermost:
-
-```python
-@jax.jit
-def compute(x, y):
-    return quax.quaxify(jnp.add)(x, y)
-```
-
 ## `vmap` in either order
 
-Here the ordering does not matter. Pick whichever describes what you mean:
-
-```python
-batched = quax.quaxify(jax.vmap(jnp.add))
-also_batched = jax.vmap(quax.quaxify(jnp.add))
-```
+Here the ordering does not matter: `quaxify(vmap(f))` and `vmap(quaxify(f))` do
+the same thing. Pick whichever describes what you mean.
 
 `grad` is the exception — there the ordering changes what type comes back. See
 [the FAQ](../faq.md#should-i-write-gradquaxifyf-or-quaxifygradf).

--- a/docs/sharp-bits.md
+++ b/docs/sharp-bits.md
@@ -52,14 +52,11 @@ return the dense array. If you want the boundary flagged, raise.
 
 ## 🔪 A gradient carries the primal's metadata, not the derivative's
 
-Differentiate a `Unitful` in metres and the cotangent is in metres. That looks
-right for `x²` and is wrong for almost everything else: the units you get are
-whatever the *input* had, because a cotangent must match the structure of its
-primal, and metadata is part of that structure.
-
-Quax cannot fix this for you, and neither can a `jax.custom_vjp` rule —
-[Autodiff](autodiff.md#metadata-on-a-cotangent-is-the-primals) has the details.
-If your metadata should transform under differentiation, track it yourself.
+Differentiate a `Unitful` in metres and the cotangent is in metres, whatever the
+derivative is actually measured in. Neither Quax nor a `jax.custom_vjp` rule can
+change this — [Autodiff](autodiff.md#metadata-on-a-cotangent-is-the-primals) has
+the why. If your metadata should transform under differentiation, track it
+yourself.
 
 ## 🔪 A loop carry cannot change its metadata
 

--- a/docs/tutorials/use-a-quax-type.md
+++ b/docs/tutorials/use-a-quax-type.md
@@ -69,10 +69,8 @@ print(type(grad).__name__, grad.units)  # Unitful {m: 1, s: -1}
 ```
 
 The gradient came back as a `Unitful` rather than a bare array, so your type
-survives the backward pass. Its units are the velocity's — a cotangent mirrors
-the primal it belongs to, which is not the same thing as carrying the
-derivative's units. [Autodiff](../autodiff.md) explains what that does and does
-not buy you.
+survives the backward pass. Its units are the velocity's, which is not the same
+thing as the derivative's — [Autodiff](../autodiff.md) covers why.
 
 ## What you did
 


### PR DESCRIPTION
Ponytail pass over #236, now that it has merged.

**−42 / +12, net −30 lines.** No page loses a point; three lose a second telling of one.

## What went

| Cut | Why |
|---|---|
| `tutorials/use-a-quax-type.md`, `sharp-bits.md` | The cotangent-metadata caveat was stated three times in one PR. `autodiff.md` keeps the explanation; the other two state the symptom and link to it. |
| `how-to/combine-with-jit-and-vmap.md` ×2 | A `@jax.jit` block demonstrating that "further out is still outermost" — the corollary of the section title it sits under. And two `vmap` bindings with no output, under prose already saying both orders work. |
| `api/unitful.md` | A bespoke worked example on a reference page, which `tutorials/use-a-quax-type.md` now does better. The registered-rules list is the reference content. |
| `how-quaxify-works.md` `tag` field | Set on the class, threaded through the rule, never printed. |
| `conftest.py` | With its code block gone, `api/unitful.md`'s Sybil pattern matched a page with nothing to run. |

## Verified

Suite **1124 passed**, down exactly 3 from #236's 1127 — the three deleted blocks, nothing else.

I re-ran the `how-quaxify-works` example by hand rather than trusting the green suite: Sybil executes blocks but does not compare printed values against the trailing comments, so a pass proves nothing about whether `# materialised` / `# ArrayImpl` / `# Tagged` are accurate. Extracted and ran it — all three match. `zensical build --clean` clean, all four hooks green.

## Kept

The `Tagged` block in `how-quaxify-works.md`. I suspected it duplicated `sharp-bits.md`'s first entry and checked before proposing the cut: that entry is allocation-from-nothing, this is the unregistered-primitive fallback, and nothing else in the docs shows case 3 turning into case 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)