### PR TITLE
refactor: hoist cond_quax's error message, and say what failed

### DIFF
--- a/src/quax/_primitives.py
+++ b/src/quax/_primitives.py
@@ -113,6 +113,11 @@ _CARRY_LEAF_COUNT_CHANGED: Final = (
     "it cannot be bound against the initial carry."
 )
 
+_COND_BRANCHES_DISAGREE: Final = (
+    "`lax.cond` branches returned different pytrees, and still disagreed after "
+    f"materialising every `quax.Value` -- see {_SHARP_BITS_URL}"
+)
+
 
 def _check_carry_stable(before: Any, after: Any, primitive: str) -> None:
     """Reject a loop body that changes a carried `Value`'s metadata.
@@ -250,7 +255,7 @@ def cond_quax(
         out_trees.clear()
         quax_branches = tuple(_make_quax_branch(j, materialise=True) for j in branches)
         if any(t != out_trees[0] for t in out_trees[1:]):
-            raise TypeError("all branches output must have the same pytree.")
+            raise TypeError(_COND_BRANCHES_DISAGREE)
 
     kwargs = {"linear": linear} if linear is not _sentinel else {}
     if branches_platforms is not _sentinel:

--- a/tests/usage/test_cond.py
+++ b/tests/usage/test_cond.py
@@ -165,7 +165,7 @@ def test_cond_mismatched_branches_materialise():
 
 
 def test_cond_mismatched_branches_reports_refusal():
-    """A type that refuses to materialise says so, rather than "same pytree"."""
+    """A type that refuses to materialise says so, not that branches disagree."""
     x = Unitful(jnp.arange(3.0), meters)
 
     with pytest.raises(ValueError, match="Refusing to materialise"):


### PR DESCRIPTION
Finishes the message hoist from #233, which left this one behind.

`_primitives.py` had four module-level `Final` message templates and one inline string. That one is now `_COND_BRANCHES_DISAGREE`, alongside the others.

## The message was also misleading

It read `all branches output must have the same pytree`. That is the *first* check's condition — but the raise sits after the branches have been retraced with every `Value` materialised, precisely to fix a pytree disagreement. Reaching it means that retrace did not help, which the old text gave no hint of. It now says so, and links to Sharp bits like its three siblings.

## No test, and why

Nothing in the suite reaches this raise, and I did not add something that does. After `materialise=True` every `Value` leaf becomes an array, so two branches can only still disagree if a `Value` materialises to a pytree rather than an array — which would violate the contract `ArrayValue` states. Constructing that means writing a deliberately broken type to exercise a branch that a correct one cannot reach.

Flagging rather than hiding it: the branch is defensive, it was untested before this change, and it still is. If you would rather have the contrived test, say so and I will add it.

`tests/usage/test_cond.py:168`'s docstring quoted the old wording ("rather than `same pytree`") and is updated to match.

Suite **1124 passed**, unchanged. Hooks green.