### PR TITLE
docs: how to recover a gradient JAX computes as NaN

### DIFF
--- a/docs/how-to/recover-a-nan-gradient.md
+++ b/docs/how-to/recover-a-nan-gradient.md
@@ -1,0 +1,108 @@
+# Recover a gradient JAX computes as NaN
+
+Some functions have a finite derivative that the chain rule cannot reach, because
+an intermediate step is singular and the singularity cancels only afterwards:
+
+```python
+import jax
+import jax.numpy as jnp
+
+
+def g(a, b):
+    return jnp.exp(jnp.log(a - b))
+
+
+print(g(1.0, 1.0))  # 0.0
+print(jax.grad(g)(1.0, 1.0))  # nan
+```
+
+`g` is `a - b`, so the derivative is `1.0`. But autodiff does not simplify. It
+differentiates `log` at zero, gets `inf`, multiplies by `exp(-inf) = 0`, and
+returns `nan`.
+
+## Defer the singular step
+
+Give the singular operation a `Value` that stands for its result without
+computing it, and register the cancelling operation to unwrap it. Then the
+`inf` never forms:
+
+```python
+from typing import Any
+
+import equinox as eqx
+import quax
+
+
+class Tracked(quax.ArrayValue):
+    array: jax.Array = eqx.field(converter=jnp.asarray)
+
+    def aval(self):
+        return jax.typeof(self.array)
+
+    def materialise(self):
+        return self.array
+
+
+class Log(quax.ArrayValue):
+    """Stands for `log(arg)`, left unevaluated."""
+
+    arg: jax.Array = eqx.field(converter=jnp.asarray)
+
+    def aval(self):
+        return jax.typeof(self.arg)
+
+    def materialise(self):
+        return jnp.log(self.arg)
+
+
+@quax.register(jax.lax.sub_p)
+def sub_tracked(a: Tracked, b: Tracked, **kw: Any) -> Tracked:
+    return Tracked(jax.lax.sub_p.bind(a.array, b.array, **kw))
+
+
+@quax.register(jax.lax.log_p)
+def log_tracked(a: Tracked, **kw: Any) -> Log:
+    return Log(a.array)
+
+
+@quax.register(jax.lax.exp_p)
+def exp_log(a: Log, **kw: Any) -> Tracked:
+    return Tracked(a.arg)  # exp(log(y)) is y, exactly
+
+
+def quax_g(a, b):
+    return quax.quaxify(g)(Tracked(a), Tracked(b)).array
+
+
+print(jax.grad(quax_g)(1.0, 1.0))  # 1.0
+```
+
+Nothing here is an approximation or a clipped gradient. `exp(log(y))` *is* `y`,
+and the rule says so, so the program being differentiated no longer contains a
+singular step. Away from the singularity the answers are unchanged:
+
+```python
+print(quax_g(3.0, 1.0), jax.grad(quax_g)(3.0, 1.0))  # 2.0 1.0
+```
+
+## Cover the whole path
+
+Every primitive between your inputs and the cancellation needs a rule. Miss one
+and that operation falls back to `materialise`, your `Tracked` becomes a plain
+array, and `log` is evaluated the ordinary way -- so you get the same `nan` back,
+with nothing to say the rules did not fire.
+
+Indexing is the usual way to trip on this: `theta[0]` is not one primitive but
+`slice_p` followed by `squeeze_p`, and neither is `sub_p`. Register those too, or
+keep the singular stretch free of indexing.
+
+[Sharp bits](../sharp-bits.md) covers the general shape of this failure. If you
+would rather it be loud, raise from `materialise` instead of returning the array
+-- an unhandled primitive is then an error rather than a silent `nan`.
+
+## When this applies
+
+The pattern needs an *exact* inverse pair, one that cancels symbolically:
+`exp`/`log` here, and equally `square`/`sqrt`, or a custom pair of your own. It
+does not help where the limit is finite but the expression does not cancel; that
+is what [`jax.custom_jvp`](../autodiff.md#custom-derivative-rules) is for.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
         - 'how-to/combine-with-jit-and-vmap.md'
         - 'how-to/resolve-an-ambiguous-rule.md'
         - 'how-to/quaxify-part-of-a-function.md'
+        - 'how-to/recover-a-nan-gradient.md'
     - Explanation:
         - 'how-quaxify-works.md'
         - 'autodiff.md'


### PR DESCRIPTION
Answers [#35](https://github.com/nstarman/quax/issues/35), which asked whether there is a general way to handle derivatives that are undefined at an intermediate step but finite once the expression cancels.

There is, and it is what Quax is for. `exp(log(a - b))` at `a == b`:

| | `jax.grad` |
|---|---|
| plain JAX | `nan` |
| with the rules on this page | `1.0` |

Autodiff differentiates `log` at zero, gets `inf`, multiplies by `exp(-inf) = 0`. Defer the `log` in a `Value` and register `exp` to unwrap it, and the singular step is no longer in the program being differentiated. Nothing is approximated or clipped — `exp(log(y))` *is* `y` — and results away from the singularity are unchanged (`g(3,1) = 2.0`, gradient `1.0`).

Two small classes, three rules, ~40 lines.

## Why a page rather than an example module

`examples/other.md` says outright that those exist to be read, not to become supported libraries. A worked how-to beats a half-maintained `quax.examples.logspace`.

This is also a category of use nothing else in the docs shows. Every existing example — units, LoRA, sparsity, named axes — propagates metadata alongside a computation. This one changes *what gets differentiated*.

## The trap gets its own section

My first two attempts at the reproduction returned `nan`, and instrumenting `Value.default` showed why: `theta[0]` lowers to `slice_p` then `squeeze_p`, neither of which had rules, so the type materialised before `log` was reached. You get your `nan` handed back with nothing to indicate the rules never fired.

That is now a section, with the suggestion to raise from `materialise` if you would rather it be loud. It is the part of this that is genuinely easy to get wrong.

## Verified

Extracted all four code blocks from the page, executed them in order, and compared against the trailing comments: `0.0`, `nan`, `1.0`, `2.0 1.0` — all match. Sybil picks the page up automatically via the existing `how-to/*.md` pattern. Suite **1127 passed** (+3 blocks), `zensical build --clean` clean, hooks green.

Not done: replying on #35 itself. That is a message to a user, so it is yours to send — say the word and I will draft it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)