### PR TITLE
docs: answer the last two recurring questions in the FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -84,3 +84,72 @@ quax.quaxify(WithMethod.doubled)(WithMethod(jnp.ones(2)))  # works
 Quaxify the method as you would any other function. `quax.quaxify(Type.method)`
 takes the instance as its first argument, so it behaves like the unbound
 function it is.
+
+## Why does `jaxtyping` reject my `Value` inside a quaxified function?
+
+Because inside the `quaxify` your function is not handed the `Value` — it is
+handed a tracer, and the tracer presents as a plain array:
+
+```python
+import jax
+import jax.numpy as jnp
+import quax
+from quax.examples.unitful import meters, Unitful
+
+
+def peek(x):
+    print(type(x).__name__)  # _QuaxTracer
+    print(jax.typeof(x))  # float32[1]
+    return x
+
+
+quax.quaxify(peek)(Unitful(jnp.asarray([1.0]), meters))
+```
+
+So a runtime typechecker sees `f32[1]` where you wrote `Unitful`, and rejects it.
+Annotate the array, not your type:
+
+```python
+import beartype
+from jaxtyping import Array, Float, jaxtyped
+
+
+@jaxtyped(typechecker=beartype.beartype)
+def double(x: Float[Array, "..."]) -> Float[Array, "..."]:
+    return x * 2.0
+
+
+out = quax.quaxify(double)(Unitful(jnp.asarray([1.0]), meters))
+print(type(out).__name__, out.units)  # Unitful {m: 1}
+```
+
+The annotation describes what the function body works with; your type is what
+crosses the `quaxify` boundary, and it still comes back out. Annotate with your
+`Value` only on functions that take it *outside* a quaxify — a constructor, or a
+rule registered with [`quax.register`][].
+
+## I get an `UnexpectedTracerError`. Is this a Quax bug?
+
+Almost certainly not, though it once was: `jnp.linalg.inv` and `jnp.linalg.solve`
+did leak tracers, and no longer do. Today the usual cause is the ordinary JAX one
+— a value escaped the transform and was used after it finished:
+
+```python
+stash = []
+
+
+def leaky(x):
+    stash.append(x)  # keeps the tracer past the trace
+    return x * 2.0
+
+
+quax.quaxify(leaky)(Unitful(jnp.asarray([1.0, 2.0]), meters))
+
+try:
+    quax.quaxify(lambda y: y * stash[0])(Unitful(jnp.asarray([1.0]), meters))
+except Exception as e:
+    print(type(e).__name__)  # UnexpectedTracerError
+```
+
+`quaxify` is a JAX transform, so JAX's rule applies unchanged: do not let a value
+outlive the call it was traced in. Return it instead of stashing it.


### PR DESCRIPTION
The two I left out of #234 because I could not answer them without guessing. Reproducing both gave answers worth writing down — and one of them is the opposite of what you would assume.

## `jaxtyping` rejects your `Value` ([#12](https://github.com/nstarman/quax/issues/12))

Inside a `quaxify` your function is never handed the `Value`. It gets a `_QuaxTracer`, whose `jax.typeof` is the array aval:

```
received type: _QuaxTracer
jax.typeof   : float32[1]
```

So a runtime typechecker reports `Actual value: f32[1]`, `Expected type: Unitful` — exactly the error in the issue, where `Shaped[Quantity, '*batch 3']` met `f64[3]`.

**The fix is to annotate the array type, not your own.** `Float[Array, "..."]` passes *and* still returns a `Unitful`, because your type is what crosses the boundary, not what the body works with. Annotate with your `Value` only outside a quaxify — constructors, and rules registered with `quax.register`.

I verified both directions rather than reasoning about one: `Unitful`-annotated raises, `Float[Array, "..."]`-annotated returns `Unitful {m: 1}`.

## `UnexpectedTracerError` ([#42](https://github.com/nstarman/quax/issues/42), [#68](https://github.com/nstarman/quax/issues/68))

The specific bug is **fixed**. #68 named `jnp.linalg.inv` and `jnp.linalg.solve`; both now run clean under `jax.check_tracer_leaks()`, and the xfail markers it mentions are gone from the suite. I checked that before writing "no longer do" — it is the kind of claim that ages badly if taken on trust.

What remains is JAX's own rule, which applies to `quaxify` unchanged: a value must not outlive the call that traced it. The entry shows the stash-it-in-a-list version that still reproduces today.

## Verified

Executed the whole page and compared every printed value against its comment — `_QuaxTracer`, `float32[1]`, `Unitful {m: 1}`, `UnexpectedTracerError`, plus the four pre-existing ones. Sybil runs the page but does not check output against comments, so a green suite alone would not have caught a wrong comment.

Suite **1130 passed** (+3 blocks), `zensical build --clean` clean, hooks green. `beartype` is already in the `tests` group, so the new block needs no dependency change.

Stacked note: this was briefly committed onto #239 by mistake and has been moved here; #239 is back to the how-to alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)