### PR TITLE
test: de-flake test_add_dense with tolerance-based comparison

### DIFF
--- a/tests/usage/test_sparse.py
+++ b/tests/usage/test_sparse.py
@@ -6,6 +6,8 @@ import jax.random as jr
 import quax
 import quax.examples.sparse as sparse
 
+from ..helpers import tree_allclose
+
 
 def _make_sparse_example(getkey):
     data = jr.normal(getkey(), (2, 4))
@@ -63,7 +65,9 @@ def test_add_dense(getkey):
         return jnp.ones((5, 1, 4)).at[idx].add(d)
 
     true_out0 = _add0(x.indices, x.data)
-    assert jnp.array_equal(out0, true_out0)
+    # `indices` contains duplicates, so both sides scatter-add into the same slot;
+    # float32 addition is not associative, so compare with a tolerance.
+    assert tree_allclose(out0, true_out0)
     assert jnp.allclose(out0, x_mat + y0)
 
     @jax.vmap
@@ -75,7 +79,7 @@ def test_add_dense(getkey):
         return base.at[idx].add(d)
 
     true_out1 = _add1(x.indices, x.data)
-    assert jnp.array_equal(out1, true_out1)
+    assert tree_allclose(out1, true_out1)
     assert jnp.allclose(out1, x_mat + y1)
 
     assert jnp.allclose(out2, x_mat + y2)


### PR DESCRIPTION
`tests/usage/test_sparse.py::test_add_dense` is intermittently flaky: it failed once in a full `uv run pytest` run and did not reproduce in isolation.

`_make_sparse_example` builds `indices_batch1 = jnp.stack([indices1, indices0, indices3, indices3])`, repeating `indices3`. Duplicate indices mean both sides of the assertion scatter-add into the same slot — `out0` through quax's `_add_bcoo_dense`, `true_out0` through the reference `jnp.ones(...).at[idx].add(d)`. Float32 addition is not associative, so a difference in summation order shows up as a last-bit mismatch under the exact `jnp.array_equal`. The data comes from an unseeded `eqxi.GetKey()`, so the draw differs every run and the failure is rare.

Swaps the two exact assertions for `tree_allclose` from `tests/helpers.py` (already used by `test_zero.py`). It is not weaker except on exactness — `typematch=True` still checks dtype and shape — and rtol=1e-5 is tight enough that a genuine indexing error still fails. The fixture's duplicate index is left alone; it looks like deliberate coverage.

## Verification

- `uv run pytest tests/usage` → 89 passed, 1 skipped.
- 2000 repetitions of both assertion bodies with fresh `eqxi.GetKey()` instances: 0 failures under either `jnp.array_equal` or `tree_allclose`.

The root cause is **not confirmed**. `_add_bcoo_dense` does structurally the same thing as the test's reference `_add0` (broadcast, then vmapped `z.at[i].add(d)`), so within one process both sides compile to the same program and agree bit-for-bit — an in-process loop cannot discriminate. That leaves the associativity theory plausible but unproven; it would need the two scatters to schedule differently, which only a differently-configured run could produce. That is consistent with the observed "once in a full suite run, never in isolation".

Only this file had the duplicate-index scatter-add hazard; the other exact `jnp.array_equal` assertions across `tests/` are exact-by-construction and are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)