### PR TITLE
test: fix test_add_dense flake with an absolute tolerance

### DIFF
--- a/tests/usage/test_sparse.py
+++ b/tests/usage/test_sparse.py
@@ -9,6 +9,11 @@ import quax.examples.sparse as sparse
 from ..helpers import tree_allclose
 
 
+# Well above float32 epsilon at the O(1) magnitudes `jr.normal` produces, and
+# well below the O(0.1) error a genuinely dropped contribution would cause.
+_ATOL = 1e-6
+
+
 def _make_sparse_example(getkey):
     data = jr.normal(getkey(), (2, 4))
     indices0 = jnp.array([2, 0, 3])
@@ -65,10 +70,14 @@ def test_add_dense(getkey):
         return jnp.ones((5, 1, 4)).at[idx].add(d)
 
     true_out0 = _add0(x.indices, x.data)
-    # `indices` contains duplicates, so both sides scatter-add into the same slot;
-    # float32 addition is not associative, so compare with a tolerance.
-    assert tree_allclose(out0, true_out0)
-    assert jnp.allclose(out0, x_mat + y0)
+    # `indices` repeats `indices3` in batch 1, so slot (1, 2, 0, 1) is a
+    # scatter-add of two `data` entries. `_add_bcoo_dense` accumulates them into
+    # the dense operand in one scatter; `materialise() + y` scatters into zeros
+    # and adds the dense operand last. Same sum, different order, so they differ
+    # by ~eps_f32 * max|summand|. When the summands cancel, that dwarfs `rtol *
+    # |result|`, so an absolute tolerance is what has to carry the comparison.
+    assert tree_allclose(out0, true_out0, atol=_ATOL)
+    assert jnp.allclose(out0, x_mat + y0, atol=_ATOL)
 
     @jax.vmap
     def _add1(i, d):
@@ -79,10 +88,10 @@ def test_add_dense(getkey):
         return base.at[idx].add(d)
 
     true_out1 = _add1(x.indices, x.data)
-    assert tree_allclose(out1, true_out1)
-    assert jnp.allclose(out1, x_mat + y1)
+    assert tree_allclose(out1, true_out1, atol=_ATOL)
+    assert jnp.allclose(out1, x_mat + y1, atol=_ATOL)
 
-    assert jnp.allclose(out2, x_mat + y2)
+    assert jnp.allclose(out2, x_mat + y2, atol=_ATOL)
 
 
 def test_add_sparse(getkey):
@@ -99,8 +108,8 @@ def test_add_sparse(getkey):
     assert z_mat.shape == (3, 2, 5, 1, 4)
     assert w.shape == (2, 5, 1, 4)
     assert w_mat.shape == (2, 5, 1, 4)
-    assert jnp.allclose(w_mat, x_mat * 2)
-    assert jnp.allclose(z_mat, x_mat + y_mat)
+    assert jnp.allclose(w_mat, x_mat * 2, atol=_ATOL)
+    assert jnp.allclose(z_mat, x_mat + y_mat, atol=_ATOL)
 
 
 def test_mul(getkey):
@@ -125,3 +134,22 @@ def test_mul(getkey):
     y2_at_indices = jax.vmap(lambda a, b: a[b])(y2, tuple_indices)
     true_out2 = sparse.BCOO(data * y2_at_indices, indices, shape)
     assert eqx.tree_equal(out2, true_out2)
+
+
+def test_add_dense_duplicate_indices():
+    """Adding a `BCOO` to a dense array accumulates repeated indices.
+
+    Deterministic, so it pins the semantics `test_add_dense` relies on: a
+    repeated index contributes every one of its `data` entries. A plain scatter
+    ("last writer wins") would give `[[2.0, -3.0]]` instead.
+    """
+    # The first two entries both target (0, 0); the third is a control.
+    indices = jnp.array([[0, 0], [0, 0], [0, 1]])
+    data = jnp.array([1.0, 2.0, -3.0])
+    x = sparse.BCOO(data, indices, (1, 2))
+    y = jnp.array([[10.0, 20.0]])
+
+    out = quax.quaxify(lambda a, b: a + b)(x, y)
+    assert jnp.array_equal(out, jnp.array([[13.0, 17.0]]))
+    x_mat = x.enable_materialise().materialise()
+    assert jnp.array_equal(x_mat, jnp.array([[3.0, -3.0]]))


### PR DESCRIPTION
## The flake

`tests/usage/test_sparse.py::test_add_dense` fails intermittently on GitHub Actions at line 85, `assert jnp.allclose(out2, x_mat + y2)`.

## What it is not

Two earlier readings were wrong, so recording both:

**Not last-bit rounding against an exact comparison.** #246 diagnosed it that way and moved lines 70/82 to `tree_allclose`. But the assertion that actually fails already used `jnp.allclose`, so loosening the other two changed nothing.

**Not a dropped contribution.** The CI output was read as showing `-1.8892099` where `-2.1419528` was expected, a difference of ~0.2477 matching a value in `data`. That reading mis-parses pytest's assertion rewriting: it renders the second argument as the *expression* `x_mat + y2`, so the two arrays printed after it are `x_mat` and `y2`, not expected-vs-actual. Every visible element checks out — e.g. `out2[0,1,0,0,0] = -1.2952805 = -1.5429394 + 0.24765903`. The failing element is inside the region pytest elided. That `0.2477` is `x_mat` sitting exactly where it belongs.

**Not a plain scatter where accumulation is meant.** `materialise()` and `_add_bcoo_dense` both use `z.at[i].add(d)`. Duplicate indices accumulate correctly on both sides.

## What it is

`indices_batch1` in `_make_sparse_example` repeats `indices3`, so slot `(1, 2, 0, 1)` is a scatter-add of two `data` entries. The two sides sum them in different orders:

- `_add_bcoo_dense` accumulates both into the dense operand in one scatter, so `y` is itself a summand.
- `materialise() + y` scatters into zeros and adds `y` last.

Same sum, different order, differing by ~`eps_f32 · max|summand|` ≈ 1e-7. Normally invisible — but when the summands cancel, `rtol · |result|` collapses toward zero and `jnp.allclose`'s default `atol=1e-8` sits below float32 rounding. It needs `|result| ≲ 0.02` at that one slot, a few percent per run: an intermittent failure.

Reproduced deterministically on macOS arm64 with `d = [1.0, 1e-7]` at the duplicated slot and `y = -1.0`:

```
quax  (y + d₁) + d₂      -> 1.0000000e-07
ref   (0 + d₁ + d₂) + y  -> 1.1920929e-07
diff  1.92e-08  >  atol 1e-8 + rtol * 1.2e-07
```

So this is not platform-specific after all. macOS arm64 happening to be bit-exact for the particular draws sampled is luck, not architecture.

quax is correct; the test's tolerance was the bug.

## The change

- `_ATOL = 1e-6` on all six sparse-vs-materialise comparisons — including the two in `test_add_sparse`, which are the same defect class and had not flaked yet. Well above float32 epsilon at the magnitudes `jr.normal` produces, and well below the O(0.1) error a genuinely dropped contribution would cause.
- `test_add_dense_duplicate_indices` pins the semantics the tolerance now assumes: a repeated index contributes every one of its `data` entries. Deterministic, no RNG.

The fixture keeps its duplicate index — it is the only coverage that duplicates accumulate at all.

## Verification

- Probe above passes at `atol=1e-6`.
- Swapping `.at[i].add(d)` → `.at[i].set(d)` in `_add_bcoo_dense` makes `test_add_dense_duplicate_indices` fail, so the guard bites.
- 25 unseeded repeat runs of the file, 4 passed each. ruff clean.

Pre-existing and unrelated to the hijax work on #245; it just keeps turning that PR's CI red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
