### PR TITLE
feat(lora): add `trainable_filter`, so `w` can be kept out of the gradient

### DIFF
--- a/docs/api/lora.md
+++ b/docs/api/lora.md
@@ -15,6 +15,8 @@ For a user who only wants to LoRA'ify only part of their model, the underlying [
         members:
             - __init__
 
+::: quax.examples.lora.trainable_filter
+
 ## Example
 
 Here's a copy of the LoRA example from the README again:

--- a/src/quax/examples/lora/__init__.py
+++ b/src/quax/examples/lora/__init__.py
@@ -1,1 +1,5 @@
-from ._core import LoraArray as LoraArray, loraify as loraify
+from ._core import (
+    LoraArray as LoraArray,
+    loraify as loraify,
+    trainable_filter as trainable_filter,
+)

--- a/src/quax/examples/lora/_core.py
+++ b/src/quax/examples/lora/_core.py
@@ -167,6 +167,60 @@ def loraify(
     return jtu.tree_map(_loraify, model, is_leaf=_is_linear)
 
 
+def _is_lora_array(x) -> bool:
+    return isinstance(x, LoraArray)
+
+
+def trainable_filter(model: PyTree) -> PyTree:
+    """Builds a filter specifying which of `model`'s arrays LoRA trains.
+
+    Every array is marked `True`, except the frozen `w` of each
+    [`quax.examples.lora.LoraArray`][] that was created with `stop_gradient=True`.
+
+    `LoraArray` holds `w` as an ordinary array field, so it is a leaf like any
+    other. Filtering it out matters twice over: it is what makes a parameter count
+    report the adaptation rather than the whole model, and -- because
+    `jax.grad` allocates a cotangent for every array it is given -- it is what
+    stops a full-size buffer of zeros being produced for a weight that is not
+    being trained.
+
+    **Arguments:**
+
+    - `model`: any PyTree, typically the output of [`quax.examples.lora.loraify`][].
+
+    **Returns:**
+
+    A PyTree of the same structure as `model`, whose leaves are booleans. Suitable
+    for `equinox.filter` and `equinox.partition`.
+
+    !!! Example
+
+        ```python
+        filter_spec = lora.trainable_filter(model)
+
+        # Count what is actually being trained.
+        n = sum(x.size for x in jtu.tree_leaves(eqx.filter(model, filter_spec)))
+
+        # Or keep the frozen weights out of the gradient entirely.
+        trainable, frozen = eqx.partition(model, filter_spec)
+
+
+        @eqx.filter_grad
+        def loss(trainable, frozen, x):
+            model = eqx.combine(trainable, frozen)
+            return ...
+        ```
+    """
+
+    def _node(x):
+        spec = jtu.tree_map(eqx.is_array, x)
+        if _is_lora_array(x) and x.stop_gradient:
+            spec = eqx.tree_at(lambda n: n._w, spec, replace=False)
+        return spec
+
+    return jtu.tree_map(_node, model, is_leaf=_is_lora_array)
+
+
 @quax.quaxify
 def _lora_array_matmul_impl(w, a, b, rhs, lhs_batch, ndim, dimension_numbers, kwargs):
     n_sharedbatch = len(lhs_batch)  # = len(rhs_batch)

--- a/tests/usage/test_lora.py
+++ b/tests/usage/test_lora.py
@@ -5,6 +5,7 @@ import jax
 import jax.lax as lax
 import jax.numpy as jnp
 import jax.random as jr
+import jax.tree_util as jtu
 import pytest
 from jaxtyping import TypeCheckError
 from plum import NotFoundLookupError
@@ -142,3 +143,62 @@ def test_regression_38(getkey):
     # `allow_materialise` is False.
     with pytest.raises((TypeError, TypeCheckError, NotFoundLookupError, RuntimeError)):
         _ = func(y)
+
+
+def _count(tree):
+    return sum(x.size for x in jtu.tree_leaves(tree) if eqx.is_array(x))
+
+
+def test_trainable_filter_counts_only_the_adaptation(getkey):
+    linear = eqx.nn.Linear(64, 32, key=getkey())
+    loraed = lora.loraify(linear, rank=4, key=getkey())
+
+    trainable = eqx.filter(loraed, lora.trainable_filter(loraed))
+
+    # a (32x4) + b (4x64) + bias (32), but not the 32x64 frozen weight.
+    assert _count(trainable) == 32 * 4 + 4 * 64 + 32
+    assert _count(loraed) == _count(trainable) + 32 * 64
+
+
+def test_trainable_filter_keeps_everything_when_not_frozen(getkey):
+    mlp = eqx.nn.MLP(2, 2, 8, 2, key=getkey())
+    loraed = lora.loraify(mlp, rank=3, stop_gradient=False, key=getkey())
+
+    trainable = eqx.filter(loraed, lora.trainable_filter(loraed))
+
+    assert _count(trainable) == _count(loraed)
+
+
+def test_trainable_filter_is_a_no_op_without_lora(getkey):
+    mlp = eqx.nn.MLP(2, 2, 8, 2, key=getkey())
+
+    trainable = eqx.filter(mlp, lora.trainable_filter(mlp))
+
+    assert _count(trainable) == _count(mlp)
+
+
+def test_trainable_filter_removes_the_zero_cotangent(getkey):
+    """Partitioning gives the same gradients without allocating one for `w`."""
+    linear = eqx.nn.Linear(64, 32, key=getkey())
+    loraed = lora.loraify(linear, rank=4, key=getkey())
+    vector = jr.normal(getkey(), (64,))
+
+    @eqx.filter_grad
+    def whole(model, x):
+        return jnp.sum(quax.quaxify(model)(x))
+
+    @eqx.filter_grad
+    def split(trainable, frozen, x):
+        return jnp.sum(quax.quaxify(eqx.combine(trainable, frozen))(x))
+
+    trainable, frozen = eqx.partition(loraed, lora.trainable_filter(loraed))
+    grad_whole = whole(loraed, vector)
+    grad_split = split(trainable, frozen, vector)
+
+    # Differentiating the whole model produces a full-size buffer of zeros.
+    assert (grad_whole.weight._w == 0).all()
+    assert grad_split.weight._w is None
+
+    assert jnp.array_equal(grad_split.weight.a, grad_whole.weight.a)
+    assert jnp.array_equal(grad_split.weight.b, grad_whole.weight.b)
+    assert jnp.array_equal(grad_split.bias, grad_whole.bias)


### PR DESCRIPTION
Closes #66, closes #28.

## They are the same bug

`LoraArray` holds `w` as an ordinary array field, so it is a pytree leaf like any other. `stop_gradient` is applied at the `.w` property (`_core.py:70-75`), which zeroes that leaf's cotangent but does not stop `jax.grad` from allocating one.

Two symptoms, one cause. Measured on a 512×256 `Linear` at rank 8:

| | naive | actual | ratio |
|---|---|---|---|
| **#66** parameter count | 137,472 | 6,400 | 21× |
| **#28** gradient pytree | 549,888 B | 25,600 B | 21.5× |

6,400 is exactly `a + b + bias`. The `w` cotangent is confirmed all-zero and genuinely allocated, so this holds regardless of whether XLA later elides a `+0` — which is where [jax#23316](https://github.com/google/jax/issues/23316) left off, and why I measured the gradient pytree rather than peak memory. `colehaus` was right to distrust the peak-usage numbers in #28; the pytree size is the unambiguous quantity.

## The addition

```python
filter_spec = lora.trainable_filter(model)

n = sum(x.size for x in jtu.tree_leaves(eqx.filter(model, filter_spec)))  # #66
trainable, frozen = eqx.partition(model, filter_spec)                     # #28
```

One function, no existing signature touched. A filter spec rather than a `partition` helper because it composes both ways — counting wants `eqx.filter`, gradients want `eqx.partition`, and a `partition` wrapper would serve only the second.

On #66 specifically: @patrick-kidger suggested counting arrays crossing the `grad` boundary. That reports the right number, but leaves the wasted allocation in place. Filtering the leaf fixes the cause, and the count falls out.

## Verified

Four tests in `tests/usage/test_lora.py`. The one that matters asserts the gradients are *unchanged*: `a`, `b` and `bias` are `array_equal` between the partitioned and unpartitioned runs, while `grad.weight._w` goes from an all-zero array to `None`.

Also checked: nested models (an MLP with 4 `LoraArray`s, 3,636 → 948), `stop_gradient=False` correctly a no-op, models with no LoRA a no-op, a jitted update step leaving `w` untouched, and calling it on an already-partitioned tree not raising.

One result that looks wrong and is not: `a` does not move on the first step, because `b` initialises to zero so `da == 0`. That is standard LoRA, and the existing `test_stop_gradient` already notes it.

Suite **1134 passed** (+4), hooks green, `zensical build --clean` clean with the new entry on the `lora` API page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)