### PR TITLE
perf(lora): stop binding a primitive to compute LoraArray's aval

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -88,9 +88,11 @@ workflow — that prompt is the authoring counterpart to this section.
   value.
 - **`aval()` must be pure**: the same instance returns the same `AbstractValue`
   every time, because quax caches it at tracer-construction time. It *may* bind
-  primitives (`lora.LoraArray.aval` calls `lax.stop_gradient`); quax evaluates it
-  under the parent trace so that this works (#216). A change touching where or
-  when `aval()` is called needs care here.
+  primitives -- quax evaluates it under the parent trace so that this works
+  (#216), and `tests/unit/test_aval_binds_primitive.py` pins it -- but it should
+  not need to: `aval` runs once per tracer, so a bind there is hot-path cost for
+  a shape and a dtype. A change touching where or when `aval()` is called needs
+  care here.
 - **A `materialise()` that raises is a design decision, not a bug.** `Unitful`,
   `LoraArray`, `NamedArray`, and the `MyArray` test fixture all raise on purpose,
   because materialising would discard the information the type exists to carry.

--- a/skills/quax/SKILL.md
+++ b/skills/quax/SKILL.md
@@ -138,9 +138,10 @@ quax.quaxify(jnp.add)(Meters(jnp.arange(3.0)), Meters(jnp.ones(3)))
 `AbstractValue` every time. Quax caches the result at tracer-construction time
 and never observes later changes.
 
-Pure does not mean array-free — `aval()` may bind JAX primitives, and
-`lora.LoraArray.aval` calls `lax.stop_gradient`. Quax evaluates it under the
-parent trace so that works. (Under jax ≤0.10 this held by luck; jax 0.11 leaves
+Pure does not mean array-free — `aval()` may bind JAX primitives, and quax
+evaluates it under the parent trace so that works. Prefer not to: `aval` runs
+once per tracer, so a bind there is on the hot path. Read the field directly
+when the primitive would not change the shape or dtype. (Under jax ≤0.10 this held by luck; jax 0.11 leaves
 no current trace at that point. Fixed on main after v0.4.3 — on v0.4.3 or
 earlier with jax 0.11, an `aval()` that binds anything fails.)
 

--- a/src/quax/_trace.py
+++ b/src/quax/_trace.py
@@ -54,14 +54,14 @@ class _QuaxTracer(core.Tracer):
             # for the trace-context manager below.
             self._cached_aval = _DenseArrayValue.aval(value)
         else:
-            # `aval()` is user code and may bind JAX primitives (e.g.
-            # `lora.LoraArray.aval` calls `lax.stop_gradient`). Tracers are
-            # constructed while the current trace has been taken -- inside
-            # `core.take_current_trace()`, or inside `Primitive.bind` while it
-            # dispatches to `process_primitive` -- and JAX >=0.11 leaves the
-            # current trace as `None` there (it used to be `eval_trace`), so
-            # binding anything would fail. Evaluate the aval under the parent
-            # trace, which is where the value's leaves live.
+            # `aval()` is user code and may bind JAX primitives (see
+            # `StopGradArray` in tests/unit/test_aval_binds_primitive.py).
+            # Tracers are constructed while the current trace has been taken --
+            # inside `core.take_current_trace()`, or inside `Primitive.bind`
+            # while it dispatches to `process_primitive` -- and JAX >=0.11
+            # leaves the current trace as `None` there (it used to be
+            # `eval_trace`), so binding anything would fail. Evaluate the aval
+            # under the parent trace, which is where the value's leaves live.
             with core.set_current_trace(trace.parent_trace):
                 self._cached_aval = type(value).aval(value)
 

--- a/src/quax/examples/lora/_core.py
+++ b/src/quax/examples/lora/_core.py
@@ -87,7 +87,12 @@ class LoraArray(quax.ArrayValue):
             )
 
     def aval(self):
-        return jax.core.ShapedArray(self.w.shape, self.w.dtype)
+        # `self._w`, not `self.w`: reading `w` binds `lax.stop_gradient`, and
+        # `aval` is called once per tracer on the hot path. Its result is the
+        # same either way -- `stop_gradient` is shape- and dtype-preserving --
+        # so going through the property bought nothing and cost a primitive
+        # bind on every tracer construction.
+        return jax.core.ShapedArray(self._w.shape, self._w.dtype)
 
 
 def _is_linear(x):

--- a/tests/unit/test_aval_binds_primitive.py
+++ b/tests/unit/test_aval_binds_primitive.py
@@ -1,8 +1,10 @@
 """`Value.aval` is user code, and may bind JAX primitives.
 
-`quax.examples.lora.LoraArray.aval` does exactly that (via `lax.stop_gradient`), and
-quax evaluates `aval()` while building tracers -- which happens with the current
-trace taken. This module pins that down with a minimal `Value`.
+Quax evaluates `aval()` while building tracers, which happens with the current
+trace taken, so a bind there only works because quax evaluates it under the
+parent trace. No shipped example relies on this any more -- `lora.LoraArray`
+used to, via `lax.stop_gradient`, until it was changed to read its weight field
+directly -- so this module is what keeps the capability covered.
 """
 
 from typing import Any, cast


### PR DESCRIPTION
## What

`LoraArray.aval` read `self.w`, and that property applies `lax.stop_gradient`. Computing the aval therefore bound a JAX primitive purely to read a shape and a dtype.

`aval` runs once per tracer, so that bind sat on the hot path. It is also the reason `LoraArray` was the standing example of an `aval()` that binds primitives — the behaviour quax core supports by evaluating `aval()` under the parent trace (#216).

Reading `self._w` instead gives the identical aval. I checked the premise rather than assuming it: `lax.stop_gradient` preserves shape and dtype for `float32`, `bfloat16` and `int32`.

## Measured

Eager `quaxify(matmul)` over a 256×256 rank-8 LoRA, both implementations interleaved in one process, best of five over 200 calls each:

| `aval()` reads | µs/call |
|---|---|
| `self.w` (binds `stop_gradient`) | 231.1 |
| `self._w` (direct) | 208.1 |

10% faster on that path.

## Scope

`materialise` and the matmul rule still read `self.w`, and correctly so — both go on to use the value, so the bind is not wasted there. `aval` was the only place that wanted nothing but the shape.

The capability is unchanged and still supported: an `aval()` may bind primitives, and `tests/unit/test_aval_binds_primitive.py` pins it with its own `StopGradArray`, independently of LoRA. But four places cited `LoraArray.aval` as *the* example, which would now be wrong. They point at that test instead, and carry the guidance the measurement justifies: an `aval()` may bind, but should not need to.

No new test. This removes logic rather than adding it, and `tests/usage/test_lora.py::test_stop_gradient` already covers both `stop_gradient` settings.

## Verification

- `uv run pytest`: 1171 passed.
- `uv run prek run --all-files`: ruff check, ruff format, pyright and taplo all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
